### PR TITLE
100% CPU Utilization

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -131,12 +131,14 @@ fd_set_connections(fd_set *rfds, fd_set *wfds, int max) {
 
                 /* Fall through */
             case(SERVER_CLOSED):
-                FD_SET(iter->client.sockfd, wfds);
+                if (buffer_len(iter->server.buffer))
+                    FD_SET(iter->client.sockfd, wfds);
 
                 max = MAX(max, iter->client.sockfd);
                 break;
             case(CLIENT_CLOSED):
-                FD_SET(iter->server.sockfd, wfds);
+                if (buffer_len(iter->client.buffer))
+                    FD_SET(iter->server.sockfd, wfds);
 
                 max = MAX(max, iter->server.sockfd);
                 break;


### PR DESCRIPTION
If you unconditionally add the sockets to wfds without checking that there is actually something to be written, select will almost always return immediatly (because sockets are almost always available for writes), and then handle_connections would do nothing.
