### PR TITLE
Fixed typo in example sniproxy.conf

### DIFF
--- a/sniproxy.conf
+++ b/sniproxy.conf
@@ -12,7 +12,7 @@ error_log {
     syslog deamon
 
     # Alternatively we could log to file
-    #filepath /var/log/sniproxy.log
+    #filename /var/log/sniproxy.log
 
     # Control the verbosity of the log
     priority notice


### PR DESCRIPTION
The `filepath` directive doesn't exist, should be `filename`.
