### PR TITLE
Removed check which was refusing to check for extensions in SSL 3.0

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -97,10 +97,8 @@ parse_tls_header(const char *data, size_t data_len, char **hostname) {
 
     tls_version_major = data[1];
     tls_version_minor = data[2];
-    if (tls_version_major < 3 ||
-        (tls_version_major == 3 && tls_version_minor < 1)) {
-        debug("Received SSL %d.%d handshake which does not support "
-              "Server Name Indication.",
+    if (tls_version_major < 3) {
+        debug("Received SSL %d.%d handshake which cannot be parsed.",
               tls_version_major, tls_version_minor);
 
         return -2;


### PR DESCRIPTION
Sniproxy contained a check that would refuse to parse an SSL 3.0 packet
for extensions. This check was wrong as SSL 3.0 explicitly allows for
additional data in the end of a Client Hello (see RFC6101 last paragraph of
5.6.1.2). In fact most browsers set SSL 3.0 as the record packet version
irrespectively of the TLS version they support (which is advertized inside
the Client Hello).

Signed-off-by: Nikos Mavrogiannopoulos nmav@redhat.com
