### PR TITLE
initialize port to 0, wildcard address test fails on OSX

### DIFF
--- a/src/address.c
+++ b/src/address.c
@@ -111,9 +111,10 @@ new_address(const char *hostname_or_ip) {
     /* Wildcard */
     if (strcmp("*", hostname_or_ip) == 0) {
         struct Address *addr = malloc(sizeof(struct Address));
-        if (addr != NULL)
+        if (addr != NULL) {
             addr->type = WILDCARD;
-        address_set_port(addr, 0);
+            address_set_port(addr, 0);
+        }
         return addr;
     }
 


### PR DESCRIPTION
I happened to compile this on my mac.

```

PASS: http_test
PASS: tls_test
PASS: buffer_test
FAIL: address_test
PASS: cfg_tokenizer_test
PASS: config_test
PASS: functional_test
PASS: bad_request_test
PASS: connection_reset_test
make[4]: Nothing to be done for `all'.
============================================================================
Testsuite summary for sniproxy 0.1
============================================================================
# TOTAL: 9
# PASS:  8
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0
============================================================================
See tests/test-suite.log
============================================================================
make[3]: *** [test-suite.log] Error 1
make[2]: *** [check-TESTS] Error 2
make[1]: *** [check-am] Error 2
make: *** [check-recursive] Error 1

cat tests/address_test.log
display_address(0x7f8ca0403af0) returned "*:2", expected "*"


```

Not really sure if thats the real problem, but this makes the tests work.
