### PR TITLE
Use -Im4 aclocal flag.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,4 @@
+ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS = src \
           tests


### PR DESCRIPTION
This will allow systems without lib-link.m4 to use the included one.

Signed-off-by: Nikos Mavrogiannopoulos nmav@redhat.com
