### PR TITLE
Fixed minor portability issues to support FreeBSD.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,8 +12,10 @@ AC_PROG_CC_C99
 # Required by automake < 1.14
 AM_PROG_CC_C_O
 
+
+
 # Checks for libraries.
-PKG_CHECK_MODULES([LIBEV], [libev],,
+PKG_CHECK_MODULES([LIBEV], [libev], HAVE_LIBEV=yes; AC_DEFINE(HAVE_LIBEV, 1),
 [AC_LIB_HAVE_LINKFLAGS(ev,, [#include <ev.h>], [ev_run(0,0);])
  if test x$ac_cv_libev = xyes; then
   AC_SUBST([LIBEV_LIBS], [$LIBEV])
@@ -24,7 +26,7 @@ PKG_CHECK_MODULES([LIBEV], [libev],,
  fi
 ])
 
-PKG_CHECK_MODULES([LIBPCRE], [libpcre],,
+PKG_CHECK_MODULES([LIBPCRE], [libpcre], HAVE_LIBPCRE=yes; AC_DEFINE(HAVE_LIBPCRE, 1),
 [AC_LIB_HAVE_LINKFLAGS(pcre,, [#include <pcre.h>], [pcre_exec(0,0,0,0,0,0,0,0);])
  if test x$ac_cv_libpcre = xyes; then
   AC_SUBST([LIBPCRE_LIBS], [$LIBPCRE])
@@ -42,13 +44,13 @@ AC_ARG_ENABLE([dns],
 AM_CONDITIONAL([DNS_ENABLED], [test "x$dns" = "xyes"])
 
 AS_IF([test "x$dns" = "xyes"],
- [PKG_CHECK_MODULES([LIBUDNS], [libudns],,
+ [PKG_CHECK_MODULES([LIBUDNS], [libudns], HAVE_LIBUDNS=yes; AC_DEFINE(HAVE_LIBUDNS, 1),
   [AC_LIB_HAVE_LINKFLAGS(udns,, [#include <udns.h>], [dns_init(0, 0);])
    AS_IF([test x$ac_cv_libudns = xyes], [AC_SUBST([LIBUDNS_LIBS], [$LIBUDNS])])
   ])
 ])
 
-PKG_CHECK_MODULES([LIBRT], [librt],,
+PKG_CHECK_MODULES([LIBRT], [librt], HAVE_LIBRT=yes; AC_DEFINE(HAVE_LIBRT, 1),
 [AC_LIB_HAVE_LINKFLAGS(rt,, [#include <time.h>], [clock_gettime(CLOCK_MONOTONIC, NULL);])
  if test x$ac_cv_librt = xyes; then
   AC_SUBST([LIBRT_LIBS], [$LIBRT])

--- a/src/binder.c
+++ b/src/binder.c
@@ -28,7 +28,11 @@
 #include <unistd.h>
 #include <string.h> /* memcpy() */
 #include <errno.h> /* errno */
+
+#ifndef __FreeBSD__
 #include <alloca.h>
+#endif /* __FreeBSD__ */
+
 #include <sys/types.h>
 #include <sys/wait.h>
 #include "binder.h"

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -32,7 +32,11 @@
 #include <time.h>
 #include <errno.h>
 #include <unistd.h>
+
+#ifndef __FreeBSD__
 #include <alloca.h>
+#endif /* __FreeBSD__ */
+
 #include <assert.h>
 #include "buffer.h"
 #include "logger.h"

--- a/src/connection.c
+++ b/src/connection.c
@@ -39,7 +39,11 @@
 #include <arpa/inet.h>
 #include <ev.h>
 #include <assert.h>
+
+#ifndef __FreeBSD__
 #include <alloca.h>
+#endif /* __FreeBSD__ */
+
 #include "connection.h"
 #include "resolv.h"
 #include "address.h"

--- a/tests/binder_test.c
+++ b/tests/binder_test.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
+#include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>


### PR DESCRIPTION
Added support so sniproxy compiles in FreeBSD.

Following issues arose when compiling:
- `alloca.h` doesn't exist (`alloca()` is defined in `stdlib.h`).
- `tests/binder_test.c` needs to include `sys/types.h` since it uses funky typedefs when defining constants such as `INADDR_LOOPBACK`.
- autoconf/pkg-config doesn't set the `HAVE_LIB{EV,UDNS,RT,PCRE}` preprocessor macros in `src/Makefile.in` so I added some minor tweaks to `configure.ac`.

`make check` passes for everything but reload configuration, which to my understanding is not yet supported.

If this is accepted, I will try to add a port to FreeBSD in the next versioned release.

Thanks.
