### PR TITLE
init script fix: $config will not be ignored

### DIFF
--- a/redhat/sniproxy.init
+++ b/redhat/sniproxy.init
@@ -33,7 +33,7 @@ start() {
     [ -f $config ] || exit 6
     echo -n $"Starting $prog: "
 
-    daemon $exec
+    daemon $exec -c $config
     retval=$?
     echo
     [ $retval -eq 0 ] && touch $lockfile


### PR DESCRIPTION
in redhat initscript was defined but not used $config variabile

Signed-off-by: Andrej Manduch amanduch@gmail.com
