### PR TITLE
[WIP] Stats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - bash -c "cd tests && ./bind_source_test valgrind --leak-check=full --error-exitcode=1"
   - bash -c "cd tests && ./reload_test valgrind --leak-check=full --error-exitcode=1"
   - echo "Testing Debian package build"
-  - dpkg-buildpackage
+  - dpkg-buildpackage -us -uc
   - echo "Testing RPM package build"
   - make dist
   - rpmbuild --define "_sourcedir `pwd`" -ba --nodeps redhat/sniproxy.spec

--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ distributions. RPM builds are tested in Travis-CI on Ubuntu, but not natively.
 This build process may not follow the current Fedora packaging standards, and
 may not even work.
 
+***Building on OS X with Homebrew***
+1. install dependencies.
+        brew install libev pcre udns autoconf automake gettext libtool
+2. Read the warning about gettext and force link it so autogen.sh works.
+        brew link --force gettext
+3. Make it so
+        ./autogen && ./configure && make
+
+OS X support is a best effort, and isn't a primary target platform.
+
 
 Configuration Syntax
 --------------------

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This is the preferred installation method on recent Debian based distributions:
 
 2. Build a Debian package
 
-        ./autogen && dpkg-buildpackage
+        ./autogen.sh && dpkg-buildpackage
 
 3. Install the resulting package
 
@@ -71,7 +71,7 @@ This is the preferred installation method for modern Fedora based distributions.
 
 2. Build a distribution tarball:
 
-        ./autogen && ./configure && make dist
+        ./autogen.sh && ./configure && make dist
 
 3. Build a RPM package
 
@@ -98,7 +98,7 @@ may not even work.
 
 3. Make it so
 
-        ./autogen && ./configure && make
+        ./autogen.sh && ./configure && make
 
 OS X support is a best effort, and isn't a primary target platform.
 

--- a/README.md
+++ b/README.md
@@ -87,11 +87,17 @@ This build process may not follow the current Fedora packaging standards, and
 may not even work.
 
 ***Building on OS X with Homebrew***
+
 1. install dependencies.
+
         brew install libev pcre udns autoconf automake gettext libtool
-2. Read the warning about gettext and force link it so autogen.sh works.
+
+2. Read the warning about gettext and force link it so autogen.sh works. We need the GNU gettext for the macro `AC_LIB_HAVE_LINKFLAGS` which isn't present in the default OS X package.
+
         brew link --force gettext
+
 3. Make it so
+
         ./autogen && ./configure && make
 
 OS X support is a best effort, and isn't a primary target platform.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This is the preferred installation method on recent Debian based distributions:
 
 2. Build a Debian package
 
-        dpkg-buildpackage
+        ./autogen && dpkg-buildpackage
 
 3. Install the resulting package
 

--- a/README.md
+++ b/README.md
@@ -51,15 +51,15 @@ This is the preferred installation method on recent Debian based distributions:
 
 1. Install required packages
 
-    sudo apt-get install autotools-dev cdbs debhelper dh-autoreconf dpkg-dev gettext libev-dev libpcre3-dev libudns-dev pkg-config
+        sudo apt-get install autotools-dev cdbs debhelper dh-autoreconf dpkg-dev gettext libev-dev libpcre3-dev libudns-dev pkg-config
 
 2. Build a Debian package
 
-    dpkg-buildpackage
+        dpkg-buildpackage
 
 3. Install the resulting package
 
-    sudo dpkg -i ../sniproxy_<version>_<arch>.deb
+        sudo dpkg -i ../sniproxy_<version>_<arch>.deb
 
 **Building Fedora/RedHat package**
 

--- a/TODO
+++ b/TODO
@@ -2,4 +2,3 @@
 * Improved table backend lookup, currently this is a linear search
 ** Considering splitting hostname at label boundaries and search backwards from TLD
 * HTTP or DNS interface for backend servers to determine remote IP and port of connection
-* Allow nameservers to be specified in configuration file (functionality currently provided by NAMESERVERS environmental variable)

--- a/debian/sniproxy.conf
+++ b/debian/sniproxy.conf
@@ -9,7 +9,7 @@ pidfile /var/run/sniproxy.pid
 
 error_log {
     # Log to the daemon syslog facility
-    syslog deamon
+    syslog daemon
 
     # Alternatively we could log to file
     #filename /var/log/sniproxy/sniproxy.log

--- a/sniproxy.conf
+++ b/sniproxy.conf
@@ -7,6 +7,32 @@ user nobody
 # PID file, needs to be placed in directory writable by user
 pidfile /var/tmp/sniproxy.pid
 
+# The DNS resolver is only required if tables are configured using wildcard or
+# hostname targets. By default the nameserver and search domain are loaded from
+# /etc/resolv.conf.
+resolver {
+    # Specify name server
+    #
+    # NOTE: it is strongly recommended to use a local caching DNS server, since
+    # uDNS and thus SNIProxy only uses single socket to each name server so
+    # each DNS query is only protected by the 16 bit query ID and lacks
+    # additional source port randomization. Additionally no caching is
+    # preformed within SNIProxy, so a local resolver can improve performance.
+    nameserver 127.0.0.1
+
+    # DNS search domain
+    search example.com
+
+    # Specify which type of address to lookup in DNS:
+    #
+    # * ipv4_only   query for IPv4 addresses (default)
+    # * ipv6_only   query for IPv6 addresses
+    # * ipv4_first  query for both IPv4 and IPv6, use IPv4 is present
+    # * ipv6_first  query for both IPv4 and IPv6, use IPv6 is present
+    #
+    mode ipv6_first
+}
+
 error_log {
     # Log to the daemon syslog facility
     syslog deamon

--- a/sniproxy.conf
+++ b/sniproxy.conf
@@ -35,7 +35,7 @@ resolver {
 
 error_log {
     # Log to the daemon syslog facility
-    syslog deamon
+    syslog daemon
 
     # Alternatively we could log to file
     #filename /var/log/sniproxy.log

--- a/src/address.c
+++ b/src/address.c
@@ -223,10 +223,13 @@ address_compare(const struct Address *addr_1, const struct Address *addr_2) {
     if (addr_1->type > addr_2->type)
         return 1;
 
-    int result = memcmp(addr_1->data, addr_2->data, MIN(addr_1->len, addr_2->len));
-    if (result == 0 && addr_1->len < addr_2->len)
+    int addr1_len = address_len(addr_1);
+    int addr2_len = address_len(addr_2);
+    int result = memcmp(addr_1->data, addr_2->data, MIN(addr1_len, addr2_len));
+
+    if (result == 0 && addr1_len < addr2_len)
         return -1;
-    if (result == 0 && addr_1->len > addr_2->len)
+    if (result == 0 && addr1_len > addr2_len)
         return 1;
 
     if (result == 0 && addr_1->port < addr_2->port)

--- a/src/address.c
+++ b/src/address.c
@@ -425,15 +425,14 @@ display_sockaddr(const void *sa, char *buffer, size_t buffer_len) {
 int
 is_numeric(const char *s) {
     char *p;
-    int n;
 
     if (s == NULL || *s == '\0')
         return 0;
 
-    n = strtod(s, &p);
+    int n = strtod(s, &p);
+    (void)n; /* unused */
 
-    return n ^ n || /* to suppress unused return value of strtod() */
-        *p == '\0'; /* to check entire string was numeric */
+    return *p == '\0'; /* entire string was numeric */
 }
 
 static int

--- a/src/address.c
+++ b/src/address.c
@@ -162,7 +162,6 @@ new_address(const char *hostname_or_ip) {
         struct Address *addr = malloc(
                 offsetof(struct Address, data) + len + 1);
         if (addr != NULL) {
-            memset(addr, 0, offsetof(struct Address, data) + len + 1);
             addr->type = HOSTNAME;
             addr->port = 0;
             addr->len = len;
@@ -186,7 +185,6 @@ new_address_sa(const struct sockaddr *sa, socklen_t sa_len) {
 
     addr = malloc(offsetof(struct Address, data) + sa_len);
     if (addr != NULL) {
-        memset(addr, 0, offsetof(struct Address, data) + sa_len);
         addr->type = SOCKADDR;
         addr->len = sa_len;
         memcpy(addr->data, sa, sa_len);

--- a/src/address.c
+++ b/src/address.c
@@ -43,8 +43,8 @@ struct Address {
         WILDCARD,
     } type;
 
-    size_t len;
-    uint16_t port;
+    size_t len;     /* length of data */
+    uint16_t port;  /* for hostname and wildcard */
     char data[];
 };
 
@@ -117,8 +117,8 @@ new_address(const char *hostname_or_ip) {
     if (strcmp("*", hostname_or_ip) == 0) {
         struct Address *addr = malloc(sizeof(struct Address));
         if (addr != NULL) {
-            memset(addr, 0, sizeof(struct Address));
             addr->type = WILDCARD;
+            addr->len = 0;
             address_set_port(addr, 0);
         }
         return addr;

--- a/src/config.c
+++ b/src/config.c
@@ -180,10 +180,10 @@ init_config(const char *filename, struct ev_loop *loop) {
     }
 
     if (parse_config(config, file, global_grammar) <= 0) {
-        uint64_t whence = ftell(file);
+        intmax_t whence = ftell(file);
         char buffer[256];
 
-        err("error parsing %s at %ld near:", filename, whence);
+        err("error parsing %s at %jd near:", filename, whence);
         fseek(file, -20, SEEK_CUR);
         for (int i = 0; i < 5; i++)
             err("%ld\t%s", ftell(file), fgets(buffer, sizeof(buffer), file));

--- a/src/config.h
+++ b/src/config.h
@@ -34,6 +34,11 @@ struct Config {
     char *filename;
     char *user;
     char *pidfile;
+    struct ResolverConfig {
+        char **nameservers;
+        char **search;
+        int mode;
+    } resolver;
     struct Logger *access_log;
     struct Listener_head listeners;
     struct Table_head tables;

--- a/src/config.h
+++ b/src/config.h
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include "table.h"
 #include "listener.h"
+#include "stats.h"
 
 struct Config {
     char *filename;
@@ -41,6 +42,7 @@ struct Config {
     } resolver;
     struct Logger *access_log;
     struct Listener_head listeners;
+    struct Stats_head stats_listeners;
     struct Table_head tables;
 };
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -238,6 +238,8 @@ connection_cb(struct ev_loop *loop, struct ev_io *w, int revents) {
         } else if (bytes_received == 0) { /* peer closed socket */
             close_socket(con, loop);
             revents = 0;
+        } else {
+            con->listener->stats.bytes_received += bytes_received;
         }
     }
 
@@ -249,6 +251,8 @@ connection_cb(struct ev_loop *loop, struct ev_io *w, int revents) {
                     strerror(errno));
 
             close_socket(con, loop);
+        } else {
+            con->listener->stats.bytes_transmitted += bytes_transmitted;
         }
     }
 

--- a/src/listener.c
+++ b/src/listener.c
@@ -65,11 +65,12 @@ void
 init_listeners(struct Listener_head *listeners,
         const struct Table_head *tables, struct ev_loop *loop) {
     struct Listener *iter;
+    char address[128];
 
     SLIST_FOREACH(iter, listeners, entries) {
         if (init_listener(iter, tables, loop) < 0) {
-            err("Failed to initialize listener");
-            print_listener_config(stderr, iter);
+            err("Failed to initialize listener %s",
+                    display_address(iter->address, address, sizeof(address)));
             exit(1);
         }
     }

--- a/src/listener.h
+++ b/src/listener.h
@@ -51,6 +51,8 @@ struct Listener {
     struct {
         size_t active_connections;
         size_t total_connections;
+        size_t bytes_transmitted;
+        size_t bytes_received;
     } stats;
 };
 

--- a/src/logger.c
+++ b/src/logger.c
@@ -441,11 +441,11 @@ free_sink(struct LogSink *sink) {
             break;
         case LOG_SINK_STDERR:
             fflush(sink->fd);
-            sink->fd == NULL;
+            sink->fd = NULL;
             break;
         case LOG_SINK_FILE:
             fclose(sink->fd);
-            sink->fd == NULL;
+            sink->fd = NULL;
             free((char *)sink->filepath);
             sink->filepath = NULL;
             break;

--- a/src/resolv.h
+++ b/src/resolv.h
@@ -30,7 +30,7 @@
 
 struct ResolvQuery;
 
-int resolv_init(struct ev_loop *);
+int resolv_init(struct ev_loop *, char **, char **, int);
 struct ResolvQuery *resolv_query(const char *, void(*)(struct Address *, void *), void (*)(void *), void *);
 void resolv_cancel(struct ResolvQuery *);
 void resolv_shutdown(struct ev_loop *);

--- a/src/sniproxy.c
+++ b/src/sniproxy.c
@@ -118,9 +118,7 @@ main(int argc, char **argv) {
     set_limits(max_nofiles);
 
     init_listeners(&config->listeners, &config->tables, EV_DEFAULT);
-    /* Fix Me */
-    struct StatsListener* stats = new_stats_listener("127.0.0.1:4000");
-    init_stats_listener(stats, EV_DEFAULT);
+    init_stats_listeners(&config->stats_listeners, EV_DEFAULT);
 
     /* Drop permissions only when we can */
     drop_perms(config->user ? config->user : default_username);
@@ -141,7 +139,7 @@ main(int argc, char **argv) {
 
     ev_run(EV_DEFAULT, 0);
 
-    free_stats_listener(stats, EV_DEFAULT);
+    free_stats_listeners(&config->stats_listeners, EV_DEFAULT);
     free_connections(EV_DEFAULT);
     resolv_shutdown(EV_DEFAULT);
 

--- a/src/sniproxy.c
+++ b/src/sniproxy.c
@@ -141,7 +141,7 @@ main(int argc, char **argv) {
 
     ev_run(EV_DEFAULT, 0);
 
-    free(stats);
+    free_stats_listener(stats, EV_DEFAULT);
     free_connections(EV_DEFAULT);
     resolv_shutdown(EV_DEFAULT);
 

--- a/src/sniproxy.c
+++ b/src/sniproxy.c
@@ -44,6 +44,7 @@
 #include "listener.h"
 #include "resolv.h"
 #include "logger.h"
+#include "stats.h"
 
 
 static void usage();
@@ -117,6 +118,9 @@ main(int argc, char **argv) {
     set_limits(max_nofiles);
 
     init_listeners(&config->listeners, &config->tables, EV_DEFAULT);
+    /* Fix Me */
+    struct StatsListener* stats = new_stats_listener("127.0.0.1:4000");
+    init_stats_listener(stats, EV_DEFAULT);
 
     /* Drop permissions only when we can */
     drop_perms(config->user ? config->user : default_username);
@@ -137,6 +141,7 @@ main(int argc, char **argv) {
 
     ev_run(EV_DEFAULT, 0);
 
+    free(stats);
     free_connections(EV_DEFAULT);
     resolv_shutdown(EV_DEFAULT);
 

--- a/src/sniproxy.c
+++ b/src/sniproxy.c
@@ -130,7 +130,8 @@ main(int argc, char **argv) {
     ev_signal_start(EV_DEFAULT, &sigint_watcher);
     ev_signal_start(EV_DEFAULT, &sigterm_watcher);
 
-    resolv_init(EV_DEFAULT);
+    resolv_init(EV_DEFAULT, config->resolver.nameservers,
+            config->resolver.search, config->resolver.mode);
 
     init_connections();
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -127,6 +127,7 @@ free_stats_listener(struct StatsListener *listener, struct ev_loop *loop) {
     ev_io_stop(loop, &listener->watcher);
 
     close(listener->watcher.fd);
+    free(listener->watcher.data);
     free(listener);
 }
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -134,6 +134,7 @@ free_stats_listener(struct StatsListener *listener, struct ev_loop *loop) {
 
     close(listener->watcher.fd);
 
+    free(listener->address);
     free(listener);
 }
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -29,16 +29,12 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <ev.h>
+#include <sys/queue.h>
+
 #include "stats.h"
 #include "address.h"
 #include "buffer.h"
 #include "logger.h"
-
-
-struct StatsListener {
-    struct Address *address;
-    struct ev_io watcher;
-};
 
 struct StatsConnection {
     struct ev_io watcher;
@@ -66,6 +62,20 @@ static void free_connection_cb(struct ev_loop *, struct ev_cleanup *, int);
 static void free_connection(struct ev_loop *, struct StatsConnection *);
 static struct StatsConnection *new_connection(struct ev_loop *);
 
+void
+init_stats_listeners(struct Stats_head *stats_listeners, struct ev_loop *loop) {
+    struct StatsListener *iter;
+    char address[128];
+
+    SLIST_FOREACH(iter, stats_listeners, entries) {
+        if (init_stats_listener(iter, loop) < 0) {
+            err("Failed to initialize listener %s",
+                    display_address(iter->address, address, sizeof(address)));
+            exit(1);
+        }
+    }
+}
+
 
 struct StatsListener *
 new_stats_listener(const char *address) {
@@ -85,12 +95,19 @@ new_stats_listener(const char *address) {
     return listener;
 }
 
-void
+int
 init_stats_listener(struct StatsListener *listener, struct ev_loop *loop) {
-    int sockfd = socket(address_sa(listener->address)->sa_family, SOCK_STREAM, 0);
+    const struct sockaddr* sock_addr = address_sa(listener->address);
+
+    if (sock_addr == NULL) {
+        err("Failed to parse sock address\n");
+        return -1;
+    }
+
+    int sockfd = socket(sock_addr->sa_family, SOCK_STREAM, 0);
     if (sockfd < 0) {
         err("%s failed to create socket: %s", __func__, strerror(errno));
-        return;
+        return sockfd;
     }
 
     int on = 1;
@@ -104,17 +121,17 @@ init_stats_listener(struct StatsListener *listener, struct ev_loop *loop) {
                 display_address(listener->address, address, sizeof(address)),
                 strerror(errno));
         close(sockfd);
-        return;
+        return result;
     }
 
-    listen(sockfd, SOMAXCONN);
+    result = listen(sockfd, SOMAXCONN);
     if (result < 0) {
         char address[128];
         err("%s failed to listener on socket to %s: %s", __func__,
                 display_address(listener->address, address, sizeof(address)),
                 strerror(errno));
         close(sockfd);
-        return;
+        return result;
     }
 
     int flags = fcntl(sockfd, F_GETFL, 0);
@@ -125,7 +142,7 @@ init_stats_listener(struct StatsListener *listener, struct ev_loop *loop) {
     listener->watcher.data = listener;
 
     ev_io_start(loop, &listener->watcher);
-
+    return 0;
 }
 
 void
@@ -265,5 +282,43 @@ connection_cb(struct ev_loop *loop, struct ev_io *w, int revents) {
         ev_io_stop(loop, w);
         ev_io_set(w, w->fd, events);
         ev_io_start(loop, w);
+    }
+}
+
+int
+accept_stats_listener_arg(struct StatsListener *listener, char *arg) {
+    if (listener->address == NULL && !is_numeric(arg)) {
+        listener->address = new_address(arg);
+
+        if (listener->address == NULL ||
+                !address_is_sockaddr(listener->address)) {
+            err("Invalid listener argument %s", arg);
+            return -1;
+        }
+    } else if (listener->address == NULL && is_numeric(arg)) {
+        listener->address = new_address("[::]");
+
+        if (listener->address == NULL ||
+                !address_is_sockaddr(listener->address)) {
+            err("Unable to initialize default address");
+            return -1;
+        }
+
+        address_set_port(listener->address, atoi(arg));
+    } else if (address_port(listener->address) == 0 && is_numeric(arg)) {
+        address_set_port(listener->address, atoi(arg));
+    } else {
+        err("Invalid listener argument %s", arg);
+    }
+
+    return 1;
+}
+
+void free_stats_listeners(struct Stats_head *stats_listeners, struct ev_loop *loop) {
+    struct StatsListener *iter;
+    char address[128];
+
+    SLIST_FOREACH(iter, stats_listeners, entries) {
+        free_stats_listener(iter, loop);
     }
 }

--- a/src/stats.c
+++ b/src/stats.c
@@ -123,10 +123,11 @@ init_stats_listener(struct StatsListener *listener, struct ev_loop *loop) {
 }
 
 void
-close_stats_listener(struct StatsListener *listener, struct ev_loop *loop) {
+free_stats_listener(struct StatsListener *listener, struct ev_loop *loop) {
     ev_io_stop(loop, &listener->watcher);
 
     close(listener->watcher.fd);
+    free(listener);
 }
 
 static void
@@ -176,6 +177,10 @@ connection_cb(struct ev_loop *loop, struct ev_io *w, int revents) {
             revents = 0;
         }
     }
+
+    char local_buffer[4096];
+    size_t length = snprintf(local_buffer, sizeof(local_buffer), "%s\n", "Hello World");
+    buffer_push(connection->output, local_buffer, length);
 
     // TODO parse request
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -162,7 +162,7 @@ connection_cb(struct ev_loop *loop, struct ev_io *w, int revents) {
 
     /* Receive first in case the socket was closed */
     if (revents & EV_READ && buffer_room(connection->input)) {
-        ssize_t bytes_received = buffer_recv(connection->input, w->fd, 0);
+        ssize_t bytes_received = buffer_recv(connection->input, w->fd, 0, loop);
         if (bytes_received < 0 && !IS_TEMPORARY_SOCKERR(errno)) {
             warn("recv(): %s, closing stats connection",
                     strerror(errno));
@@ -181,7 +181,7 @@ connection_cb(struct ev_loop *loop, struct ev_io *w, int revents) {
 
     /* Transmit */
     if (revents & EV_WRITE && buffer_len(connection->output)) {
-        ssize_t bytes_transmitted = buffer_send(connection->output, w->fd, 0);
+        ssize_t bytes_transmitted = buffer_send(connection->output, w->fd, 0, loop);
         if (bytes_transmitted < 0 && !IS_TEMPORARY_SOCKERR(errno)) {
             warn("send(): %s, closing stats connection",
                     strerror(errno));

--- a/src/stats.c
+++ b/src/stats.c
@@ -64,17 +64,10 @@ static struct StatsConnection *new_connection(struct ev_loop *);
 
 
 struct StatsListener *
-new_stats_listener(const char *address) {
-    struct StatsListener *listener = malloc(sizeof(struct StatsListener));
+new_stats_listener() {
+    struct StatsListener *listener = calloc(1, sizeof(struct StatsListener));
     if (listener == NULL) {
         err("%s failed to allocate memory for listener", __func__);
-        return NULL;
-    }
-
-    listener->address = new_address(address);
-    if (listener->address == NULL) {
-        err("%s invalid address", __func__);
-        free(listener);
         return NULL;
     }
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -145,8 +145,8 @@ accept_cb(struct ev_loop *loop, struct ev_io *w, int revents) {
         ev_io_init(&connection->watcher, connection_cb, sockfd, EV_READ | EV_WRITE);
         connection->watcher.data = connection;
 
-        connection->input = new_buffer(256);
-        connection->output = new_buffer(16 * 1024);
+        connection->input = new_buffer(256, loop);
+        connection->output = new_buffer(16 * 1024, loop);
 
         ev_io_start(loop, &connection->watcher);
     }

--- a/src/stats.h
+++ b/src/stats.h
@@ -37,7 +37,7 @@ struct StatsListener {
     SLIST_ENTRY(StatsListener) entries;
 };
 
-struct StatsListener *new_stats_listener(const char *);
+struct StatsListener *new_stats_listener();
 int accept_stats_listener_arg(struct StatsListener *listener, char *arg);
 
 void init_stats_listeners(struct Stats_head *, struct ev_loop *);

--- a/src/stats.h
+++ b/src/stats.h
@@ -35,6 +35,6 @@ struct StatsListener;
 
 struct StatsListener *new_stats_listener(const char *);
 void init_stats_listener(struct StatsListener *, struct ev_loop *);
-void close_stats_listener(struct StatsListener *, struct ev_loop *);
+void free_stats_listener(struct StatsListener *, struct ev_loop *);
 
 #endif

--- a/src/stats.h
+++ b/src/stats.h
@@ -30,11 +30,16 @@
 #include "address.h"
 #include "table.h"
 
-struct StatsListener;
-
+SLIST_HEAD(Stats_head, StatsListener);
+struct StatsListener {
+    struct Address *address;
+    struct ev_io watcher;
+    SLIST_ENTRY(StatsListener) entries;
+};
 
 struct StatsListener *new_stats_listener(const char *);
-void init_stats_listener(struct StatsListener *, struct ev_loop *);
+int accept_stats_listener_arg(struct StatsListener *listener, char *arg);
+int init_stats_listener(struct StatsListener *, struct ev_loop *);
 void free_stats_listener(struct StatsListener *, struct ev_loop *);
 
 #endif

--- a/src/stats.h
+++ b/src/stats.h
@@ -39,7 +39,7 @@ struct StatsListener {
 
 struct StatsListener *new_stats_listener(const char *);
 int accept_stats_listener_arg(struct StatsListener *listener, char *arg);
-int init_stats_listener(struct StatsListener *, struct ev_loop *);
-void free_stats_listener(struct StatsListener *, struct ev_loop *);
 
+void init_stats_listeners(struct Stats_head *, struct ev_loop *);
+void free_stats_listeners(struct Stats_head *, struct ev_loop *);
 #endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -68,7 +68,9 @@ config_test_SOURCES = config_test.c \
                       ../src/resolv.c \
                       ../src/resolv.h \
                       ../src/tls.c \
-                      ../src/http.c
+                      ../src/http.c \
+                      ../src/stats.h \
+                      ../src/stats.c
 
 config_test_LDADD = $(LIBEV_LIBS) $(LIBPCRE_LIBS) $(LIBUDNS_LIBS)
 

--- a/tests/address_test.c
+++ b/tests/address_test.c
@@ -135,6 +135,7 @@ int main() {
 
     assert(compare_address_strings("unix:/dev/log", "127.0.0.1") < 0);
     assert(compare_address_strings("unix:/dev/log", "unix:/dev/logsocket") < 0);
+    assert(compare_address_strings("example.co", "example.com") != 0);
     assert(compare_address_strings("0.0.0.0", "127.0.0.1") < 0);
     assert(compare_address_strings("127.0.0.1", "0.0.0.0") > 0);
     assert(compare_address_strings("127.0.0.1", "127.0.0.1") == 0);

--- a/tests/address_test.c
+++ b/tests/address_test.c
@@ -63,7 +63,7 @@ int compare_address_strings(const char *a, const char *b) {
 }
 
 int main() {
-    /* using volatile variables so we can example core dumps */
+    /* using volatile variables so we can examine core dumps */
     for (volatile unsigned int i = 0; i < sizeof(good) / sizeof(struct Test); i++) {
         int port;
         char buffer[255];

--- a/tests/resolv_test.c
+++ b/tests/resolv_test.c
@@ -39,7 +39,7 @@ int main() {
     struct ev_timer timeout_watcher;
     struct ev_timer init_watcher;
 
-    resolv_init(loop);
+    resolv_init(loop, NULL, NULL, 0);
 
     ev_timer_init(&init_watcher, &test_init_cb, 0.0, 0.0);
     ev_timer_start(loop, &init_watcher);


### PR DESCRIPTION
This adds a hard coded stats listener at `127.0.0.1:4000`.
The listener just accepts connections and sits there.
Chrome crashes the listener because we hit the assert.
There isn't a configuration syntax to make a listener, and I wanted feedback before I implemented it.

#### On the topic of configuration
With the existing configuration syntax, I think the easiest way to add stats would be:
```
listener 127.0.0.1:4000 {
    protocol stats
}
```

Stats isn't really a protocol per-se. I'm thinking it would be some sort of formatted text, maybe HTTP, JSON, who knows.

The alternative is to add a special case of listener like

```
stats 127.0.0.1:4000 {
  # optional body
}
```
I think the first option is easier in the short term.