### PR TITLE
Fix Spelling Mistakes

### DIFF
--- a/debian/sniproxy.conf
+++ b/debian/sniproxy.conf
@@ -9,7 +9,7 @@ pidfile /var/run/sniproxy.pid
 
 error_log {
     # Log to the daemon syslog facility
-    syslog deamon
+    syslog daemon
 
     # Alternatively we could log to file
     #filename /var/log/sniproxy/sniproxy.log

--- a/sniproxy.conf
+++ b/sniproxy.conf
@@ -35,7 +35,7 @@ resolver {
 
 error_log {
     # Log to the daemon syslog facility
-    syslog deamon
+    syslog daemon
 
     # Alternatively we could log to file
     #filename /var/log/sniproxy.log


### PR DESCRIPTION
I think this should be `syslog daemon` 
not `syslog deamon` 
