### PR TITLE
Update logger.c

### DIFF
--- a/src/logger.c
+++ b/src/logger.c
@@ -128,6 +128,8 @@ reopen_loggers() {
             if (sink->fd == NULL)
                 err("failed to reopen log file %s: %s",
                         sink->filepath, strerror(errno));
+            else
+                setvbuf(sink->fd, NULL, _IOLBF, 0);
         }
     }
 }


### PR DESCRIPTION
reopen logger is not setting IOLBF as default logger does, causing access log parser failure.