### PR TITLE
Update buffer.c

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -194,6 +194,8 @@ buffer_write(struct Buffer *buffer, int fd) {
 
 size_t
 buffer_coalesce(struct Buffer *buffer, const void **dst) {
+    if (buffer->len == 0) return 0;
+    
     if ((buffer->head + buffer->len) % buffer->size > buffer->head) {
         if (dst != NULL)
             *dst = &buffer->buffer[buffer->head];


### PR DESCRIPTION
buffer_coalesce reads buffer->len as 4096 when buffer->head is non-zero and buffer->len is 0 to start with. buffer_push will change buffer_len. This causes assertion failure and sniProxy crash at line 211/213(after code change) assert(buffer->len == len);

In usual scenario it may not happen, but still safer to protect. Please suggest if better to fix it in buffer_push()