### PR TITLE
Fix a crash when a listener does not have an address

### DIFF
--- a/src/listener.c
+++ b/src/listener.c
@@ -247,7 +247,7 @@ accept_listener_protocol(struct Listener *listener, char *protocol) {
     else
         listener->protocol = tls_protocol;
 
-    if (address_port(listener->address) == 0)
+    if (listener->address != NULL && address_port(listener->address) == 0)
         address_set_port(listener->address, listener->protocol->default_port);
 
     return 1;


### PR DESCRIPTION
sniproxy fails later as the configuration is not valid, no need to crash here.
