### PR TITLE
Report an error in case of an invalid port, instead of `assert(0)`

### DIFF
--- a/src/address.c
+++ b/src/address.c
@@ -107,7 +107,7 @@ new_address(const char *hostname_or_ip) {
 
             struct Address *addr = new_address(ip_buf);
             if (addr != NULL)
-                address_set_port(addr, port_num);
+                address_set_port(addr, (uint16_t) port_num);
 
             return addr;
         }
@@ -293,7 +293,7 @@ address_sa_len(const struct Address *addr) {
     return addr->len;
 }
 
-int
+uint16_t
 address_port(const struct Address *addr) {
     switch (addr->type) {
         case HOSTNAME:
@@ -323,12 +323,7 @@ address_port(const struct Address *addr) {
 }
 
 void
-address_set_port(struct Address *addr, int port) {
-    if (port < 0 || port > 65535) {
-        assert(0);
-        return;
-    }
-
+address_set_port(struct Address *addr, uint16_t port) {
     switch (addr->type) {
         case SOCKADDR:
             switch (address_sa(addr)->sa_family) {
@@ -356,6 +351,16 @@ address_set_port(struct Address *addr, int port) {
             /* invalid Address type */
             assert(0);
     }
+}
+
+int
+address_set_port_str(struct Address *addr, const char* str) {
+    int port = atoi(str);
+    if (port < 0 || port > 65535) {
+        return 0;
+    }
+    address_set_port(addr, (uint16_t) port);
+    return 1;
 }
 
 const char *

--- a/src/address.h
+++ b/src/address.h
@@ -26,6 +26,7 @@
 #ifndef ADDRESS_H
 #define ADDRESS_H
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <sys/socket.h>
@@ -49,8 +50,9 @@ int address_is_wildcard(const struct Address *);
 const char *address_hostname(const struct Address *);
 const struct sockaddr *address_sa(const struct Address *);
 socklen_t address_sa_len(const struct Address *);
-int address_port(const struct Address *);
-void address_set_port(struct Address *, int);
+uint16_t address_port(const struct Address *);
+void address_set_port(struct Address *, uint16_t);
+int address_set_port_str(struct Address *addr, const char* str);
 const char *display_address(const struct Address *, char *, size_t);
 const char *display_sockaddr(const void *, char *, size_t);
 int is_numeric(const char *);

--- a/src/backend.c
+++ b/src/backend.c
@@ -72,7 +72,10 @@ accept_backend_arg(struct Backend *backend, const char *arg) {
         }
 #endif
     } else if (address_port(backend->address) == 0 && is_numeric(arg)) {
-        address_set_port(backend->address, atoi(arg));
+        if (!address_set_port_str(backend->address, arg)) {
+            err("Invalid port: %s", arg);
+            return -1;
+        }
     } else {
         err("Unexpected table backend argument: %s", arg);
         return -1;

--- a/src/listener.c
+++ b/src/listener.c
@@ -219,10 +219,15 @@ accept_listener_arg(struct Listener *listener, char *arg) {
             err("Unable to initialize default address");
             return -1;
         }
-
-        address_set_port(listener->address, atoi(arg));
+        if (!address_set_port_str(listener->address, arg)) {
+            err("Invalid port %s", arg);
+            return -1;
+        }
     } else if (address_port(listener->address) == 0 && is_numeric(arg)) {
-        address_set_port(listener->address, atoi(arg));
+        if (!address_set_port_str(listener->address, arg)) {
+            err("Invalid port %s", arg);
+            return -1;
+        }
     } else {
         err("Invalid listener argument %s", arg);
     }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -26,9 +26,11 @@
 #ifndef PROTOCOL_H
 #define PROTOCOL_H
 
+#include <inttypes.h>
+
 struct Protocol {
     const char *const name;
-    const int default_port;
+    const uint16_t default_port;
     int (*const parse_packet)(const char*, size_t, char **);
     const char *const abort_message;
     const size_t abort_message_len;


### PR DESCRIPTION
I changed the port type from `int` to `uint16_t` because it seems more fitting, but I can rewrite this PR keeping `int`. The main point is to move the check as near as possible to the actual parsing to be able to report a useful error message.