### PR TITLE
Show table entry using default port in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ Configuration Syntax
     table TableName {
         # Match exact request hostnames
         example.com 192.0.2.10:4343
-        example.net [2001:DB8::1:10]:443
+        # If port is not specified the listener port will be used
+        example.net [2001:DB8::1:10]
         # Or use regular expression to match
         .*\\.com    [2001:DB8::1:11]:443
         # Combining regular expression and wildcard will resolve the hostname


### PR DESCRIPTION
Remove the port specification from one of the example table entries in
the README file and add a comment explaining that the port number from
the listener will be used.

I'm looking to set this up to proxy both http and https traffic using
the same mappings from host name to backend, so I was curious if I'd
need to duplicate that information. Reading the source of the man page I
learned that this feature would let me avoid the duplication, but future
people looking at this may find it nice to be able to learn that from
the README file.