### PR TITLE
Bind device for some platform using SO_BINDTODEVICE, root required.

### DIFF
--- a/sniproxy.conf
+++ b/sniproxy.conf
@@ -67,6 +67,12 @@ listen 80 {
     # maximum number of simultaneous connections possible.
     source 192.0.2.10
 
+    # Bind device for outgoing connections
+    #
+    # This is not available for all platforms.
+    # Root is required for SO_BINDTODEVICE
+    #device eth1
+
     # Log the content of bad requests
     #bad_requests log
 

--- a/src/config.c
+++ b/src/config.c
@@ -119,6 +119,14 @@ struct Keyword listener_stanza_grammar[] = {
             (int(*)(void *, char *))accept_listener_source_address,
             NULL,
             NULL},
+
+#ifdef SO_BINDTODEVICE
+    { "device",
+            NULL,
+            (int(*)(void *, char *))accept_listener_device_name,
+            NULL,
+            NULL},
+#endif
     { "access_log",
             (void *(*)())new_logger_builder,
             (int(*)(void *, char *))accept_logger_filename,

--- a/src/listener.h
+++ b/src/listener.h
@@ -41,6 +41,10 @@ struct Listener {
     struct Logger *access_log;
     int log_bad_requests;
 
+#ifdef SO_BINDTODEVICE
+    char *device_name;
+#endif
+
     /* Runtime fields */
     int reference_count;
     struct ev_io watcher;
@@ -55,6 +59,9 @@ int accept_listener_arg(struct Listener *, char *);
 int accept_listener_table_name(struct Listener *, char *);
 int accept_listener_fallback_address(struct Listener *, char *);
 int accept_listener_source_address(struct Listener *, char *);
+#ifdef SO_BINDTODEVICE
+int accept_listener_device_name(struct Listener *, char *);
+#endif
 int accept_listener_protocol(struct Listener *, char *);
 int accept_listener_bad_request_action(struct Listener *, char *);
 


### PR DESCRIPTION
I set up sniproxy on my router (linux based, listening on secondary ip), with Internet and a VPN connection, dnsmasq is configured to hijack domains to sniproxy's IP and sniproxy forward those requests via VPN interface.

I tried to use **source**, but traffics still follow system route table.

So I tried to make changes on sniproxy, https://github.com/sskaje/sniproxy/commit/8912987ab314ef6df664bcbb535a2b44e33d77f2

SO_BINDTODEVICE is used to bind client interface, but root is required.

I guess this is not recommended, but someone like me may need this.
