### PR TITLE
Use accept4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,12 +6,12 @@ AC_INIT([sniproxy], [0.4.0])
 AC_CONFIG_SRCDIR([src/sniproxy.c])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([subdir-objects])
+AC_GNU_SOURCE
 
 # Checks for programs.
 AC_PROG_CC_C99
 # Required by automake < 1.14
 AM_PROG_CC_C_O
-
 
 
 # Checks for libraries.
@@ -74,6 +74,8 @@ AC_FUNC_MALLOC
 AC_FUNC_STRTOD
 AC_CHECK_FUNCS([daemon memset socket strcasecmp strdup strerror strncasecmp],,
     AC_MSG_ERROR([required functions(s) not found]))
+
+AC_CHECK_FUNCS([accept4])
 
 # Enable large file support (so we can log more than 2GB)
 AC_SYS_LARGEFILE

--- a/src/binder.c
+++ b/src/binder.c
@@ -172,7 +172,12 @@ binder_main(int sockfd) {
 
         /* set SO_REUSEADDR on server socket to facilitate restart */
         int on = 1;
-        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+        int result = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+        if (result < 0) {
+            memset(buffer, 0, sizeof(buffer));
+            snprintf(buffer, sizeof(buffer), "setsockopt SO_REUSEADDR failed: %s", strerror(errno));
+            goto error;
+        }
 
         if (bind(fd, req->address, req->address_len) < 0) {
             memset(buffer, 0, sizeof(buffer));

--- a/src/connection.c
+++ b/src/connection.c
@@ -488,9 +488,15 @@ initiate_server_connect(struct Connection *con, struct ev_loop *loop) {
 
     if (con->listener->source_address) {
         int on = 1;
-        setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+        int result = setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+        if (result < 0) {
+            err("setsockopt SO_REUSEADDR failed: %s", strerror(errno));
+            close(sockfd);
+            abort_connection(con);
+            return;
+        }
 
-        int result = 0;
+        result = 0;
         int tries = 5;
         do {
             result = bind(sockfd,

--- a/src/listener.c
+++ b/src/listener.c
@@ -427,9 +427,14 @@ init_listener(struct Listener *listener, const struct Table_head *tables, struct
 
     /* set SO_REUSEADDR on server socket to facilitate restart */
     int on = 1;
-    setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+    int result = setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+    if (result < 0) {
+        err("setsockopt SO_REUSEADDR failed: %s", strerror(errno));
+        close(sockfd);
+        return result;
+    }
 
-    int result = bind(sockfd, address_sa(listener->address),
+    result = bind(sockfd, address_sa(listener->address),
             address_sa_len(listener->address));
     if (result < 0 && errno == EACCES) {
         /* Retry using binder module */

--- a/src/listener.c
+++ b/src/listener.c
@@ -422,7 +422,7 @@ init_listener(struct Listener *listener, const struct Table_head *tables, struct
     int sockfd = socket(address_sa(listener->address)->sa_family, SOCK_STREAM, 0);
     if (sockfd < 0) {
         err("socket failed: %s", strerror(errno));
-        return -2;
+        return sockfd;
     }
 
     /* set SO_REUSEADDR on server socket to facilitate restart */
@@ -439,21 +439,21 @@ init_listener(struct Listener *listener, const struct Table_head *tables, struct
         if (sockfd < 0) {
             err("binder failed to bind to %s",
                 display_address(listener->address, address, sizeof(address)));
-            close(sockfd);
-            return -3;
+            return sockfd;
         }
     } else if (result < 0) {
         err("bind %s failed: %s",
             display_address(listener->address, address, sizeof(address)),
             strerror(errno));
         close(sockfd);
-        return -3;
+        return result;
     }
 
-    if (listen(sockfd, SOMAXCONN) < 0) {
+    result = listen(sockfd, SOMAXCONN);
+    if (result < 0) {
         err("listen failed: %s", strerror(errno));
         close(sockfd);
-        return -4;
+        return result;
     }
 
 

--- a/src/sniproxy.c
+++ b/src/sniproxy.c
@@ -218,19 +218,19 @@ drop_perms(const char *username) {
     errno = 0;
     struct passwd *user = getpwnam(username);
     if (errno)
-        perror_exit("getpwnam()");
+        fatal("getpwnam(): %s", strerror(errno));
     else if (user == NULL)
         fatal("getpwnam(): user %s does not exist", username);
 
     /* drop any supplementary groups */
     if (setgroups(1, &user->pw_gid) < 0)
-        perror_exit("setgroups()");
+        fatal("setgroups(): %s", strerror(errno));
 
     if (setgid(user->pw_gid) < 0)
-        perror_exit("setgid()");
+        fatal("setgid(): %s", strerror(errno));
 
     if (setuid(user->pw_uid) < 0)
-        perror_exit("setuid()");
+        fatal("setuid(): %s", strerror(errno));
 }
 
 static void


### PR DESCRIPTION
Use accept4 and socket type flags provided by Linux and recent OpenBSD version to avoid two `fnctl()` calls on each new socket.