### PR TITLE
Transparent Proxy Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ install:
   - mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
   - ./autogen.sh
 script:
-  - echo "Running unit tests"
+  - echo "Running unit and functional tests"
   - ./configure
   - make all check
+  - bash -c "cd tests && sudo ./transparent_proxy_test"
   - echo "Checking for memory leaks"
   - bash -c "cd tests && ./bad_dns_request_test valgrind --leak-check=full --error-exitcode=1"
   - bash -c "cd tests && ./bad_request_test valgrind --leak-check=full --error-exitcode=1"

--- a/sniproxy.conf
+++ b/sniproxy.conf
@@ -59,12 +59,15 @@ listen 80 {
 
     # Specify the source address for outgoing connections.
     #
+    # Use "source client" to enable transparent proxy support. This requires
+    # running sniproxy as root ("user root").
+    #
     # Do not include a port in this address, otherwise you will be limited
     # to a single connection to each backend server.
     #
-    # NOTE: using this option prevents the operating system from selecting
-    # and source address and port optimally and may significantly reduce the
-    # maximum number of simultaneous connections possible.
+    # NOTE: binding to a specific address prevents the operating system from
+    # selecting and source address and port optimally and may significantly
+    # reduce the maximum number of simultaneous connections possible.
     source 192.0.2.10
 
     # Log the content of bad requests

--- a/src/config.c
+++ b/src/config.c
@@ -180,6 +180,7 @@ static struct Keyword global_grammar[] = {
 };
 
 static const char *resolver_mode_names[] = {
+    "DEFAULT",
     "ipv4_only",
     "ipv6_only",
     "ipv4_first",

--- a/src/connection.c
+++ b/src/connection.c
@@ -526,7 +526,13 @@ initiate_server_connect(struct Connection *con, struct ev_loop *loop) {
     if (con->listener->transparent_proxy &&
             con->client.addr.ss_family == con->server.addr.ss_family) {
         int on = 1;
+#ifdef IP_TRANSPARENT
         int result = setsockopt(sockfd, SOL_IP, IP_TRANSPARENT, &on, sizeof(on));
+#else
+        int result = -EPERM;
+        /* XXX error: not implemented would be better, but this shouldn't be
+         * reached since it is prohibited in the configuration parser. */
+#endif
         if (result < 0) {
             err("setsockopt IP_TRANSPARENT failed: %s", strerror(errno));
             close(sockfd);

--- a/src/listener.c
+++ b/src/listener.c
@@ -304,8 +304,13 @@ accept_listener_source_address(struct Listener *listener, char *source) {
     }
 
     if (strcasecmp("client", source) == 0) {
+#ifdef IP_TRANSPARENT
         listener->transparent_proxy = 1;
         return 1;
+#else
+        err("Transparent proxy not supported on this platform.");
+        return 0;
+#endif
     }
 
     listener->source_address = new_address(source);

--- a/src/listener.c
+++ b/src/listener.c
@@ -190,6 +190,7 @@ new_listener() {
     listener->protocol = tls_protocol;
     listener->table_name = NULL;
     listener->access_log = NULL;
+    listener->transparent_proxy = 0;
     listener->log_bad_requests = 0;
     listener->reference_count = 0;
     /* Initializes sock fd to negative sentinel value to indicate watchers
@@ -297,9 +298,14 @@ accept_listener_fallback_address(struct Listener *listener, char *fallback) {
 
 int
 accept_listener_source_address(struct Listener *listener, char *source) {
-    if (listener->source_address != NULL) {
+    if (listener->source_address != NULL || listener->transparent_proxy) {
         err("Duplicate source address: %s", source);
         return 0;
+    }
+
+    if (strcasecmp("client", source) == 0) {
+        listener->transparent_proxy = 1;
+        return 1;
     }
 
     listener->source_address = new_address(source);

--- a/src/listener.h
+++ b/src/listener.h
@@ -39,7 +39,7 @@ struct Listener {
     const struct Protocol *protocol;
     char *table_name;
     struct Logger *access_log;
-    int log_bad_requests;
+    int transparent_proxy, log_bad_requests;
 
     /* Runtime fields */
     int reference_count;

--- a/src/resolv.h
+++ b/src/resolv.h
@@ -31,8 +31,15 @@
 struct ResolvQuery;
 
 int resolv_init(struct ev_loop *, char **, char **, int);
-struct ResolvQuery *resolv_query(const char *, void(*)(struct Address *, void *), void (*)(void *), void *);
+struct ResolvQuery *resolv_query(const char *, int,
+        void(*)(struct Address *, void *), void (*)(void *), void *);
 void resolv_cancel(struct ResolvQuery *);
 void resolv_shutdown(struct ev_loop *);
+
+static const int RESOLV_MODE_DEFAULT = 0;
+static const int RESOLV_MODE_IPV4_ONLY = 1;
+static const int RESOLV_MODE_IPV6_ONLY = 2;
+static const int RESOLV_MODE_IPV4_FIRST = 3;
+static const int RESOLV_MODE_IPV6_FIRST = 4;
 
 #endif

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -9,3 +9,4 @@ table_test
 tls_test
 *.log
 *.trs
+*.pcap

--- a/tests/TestHTTPD.pm
+++ b/tests/TestHTTPD.pm
@@ -49,12 +49,14 @@ sub default_response_generator {
 }
 
 sub httpd {
-    my $port = shift;
-    my $responder_generator = shift || \&default_response_generator;
+    my %args = @_;
+    my $ip = $args{'ip'} || 'localhost';
+    my $port = $args{'port'} || 8081;
+    my $responder_generator = $args{'generator'} || \&default_response_generator;
 
     my $server = IO::Socket::INET->new(Listen    => Socket::SOMAXCONN(),
                                        Proto     => 'tcp',
-                                       LocalAddr => 'localhost',
+                                       LocalAddr => $ip,
                                        LocalPort => $port,
                                        ReuseAddr => 1)
         or die $!;

--- a/tests/TestUtils.pm
+++ b/tests/TestUtils.pm
@@ -74,7 +74,7 @@ sub reap_children {
         exit 1;
     } else {
         # print "Test passed.\n";
-        exit 0;
+        return;
     }
 }
 
@@ -86,17 +86,19 @@ sub wait_for_type($) {
     }
 }
 
-sub wait_for_port($) {
-    my $port = shift;
+sub wait_for_port {
+    my %args = @_;
+    my $ip = $args{'ip'} || 'localhost';
+    my $port = $args{'port'} or die "port required";
 
     my $delay = 1;
     while ($delay < 60) {
         my $port_open = undef;
         eval {
-            my $socket = IO::Socket::INET->new(PeerAddr => '127.0.0.1',
-                                            PeerPort => $port,
-                                            Proto => "tcp",
-                                            Type => SOCK_STREAM);
+            my $socket = IO::Socket::INET->new(PeerAddr => $ip,
+                                               PeerPort => $port,
+                                               Proto => "tcp",
+                                               Type => SOCK_STREAM);
             if ($socket && $socket->connected()) {
                 $socket->shutdown(2);
                 $port_open = 1;

--- a/tests/bad_dns_request_test
+++ b/tests/bad_dns_request_test
@@ -136,7 +136,7 @@ sub main {
     my $proxy_pid = start_child('server', \&proxy, $config, @ARGV);
 
     # Wait for proxy to load and parse config
-    wait_for_port($proxy_port);
+    wait_for_port(port => $proxy_port);
 
     for (my $i = 0; $i < $workers; $i++) {
         start_child('worker', \&worker, $proxy_port, $iterations, $i);

--- a/tests/bad_request_test
+++ b/tests/bad_request_test
@@ -334,7 +334,7 @@ sub main {
     my $proxy_pid = start_child('server', \&proxy, $config, @ARGV);
 
     # Wait for proxy to load and parse config
-    wait_for_port($proxy_port);
+    wait_for_port(port => $proxy_port);
 
     for (my $i = 0; $i < $workers; $i++) {
         start_child('worker', \&worker, 'localhost', '', $proxy_port, $iterations);

--- a/tests/bench_sniproxy
+++ b/tests/bench_sniproxy
@@ -6,7 +6,7 @@ if [ -n "${LOCAL_HTTPD_PORT}" ]; then
 else
     TEST_HTTPD_PORT=${TEST_HTTPD_PORT:=8081}
     # Start TestHTTPD
-    perl -MTestHTTPD -e "TestHTTPD::httpd(${TEST_HTTPD_PORT})" &
+    perl -MTestHTTPD -e "TestHTTPD::httpd(port => ${TEST_HTTPD_PORT})" &
     TEST_HTTPD_PID=$!
 fi
 

--- a/tests/bench_test_httpd
+++ b/tests/bench_test_httpd
@@ -2,7 +2,7 @@
 
 TEST_HTTPD_PORT=8081
 
-perl -MTestHTTPD -e "TestHTTPD::httpd(${TEST_HTTPD_PORT})" &
+perl -MTestHTTPD -e "TestHTTPD::httpd(port => ${TEST_HTTPD_PORT})" &
 TEST_HTTPD_PID=$!
 
 echo -n "Wait for TestHTTPD to start"

--- a/tests/bind_source_test
+++ b/tests/bind_source_test
@@ -71,11 +71,11 @@ sub main {
 
     my $config = make_source_config($proxy_port, $local_httpd || $httpd_port);
     my $proxy_pid = start_child('server', \&proxy, $config, @ARGV);
-    my $httpd_pid = start_child('server', \&TestHTTPD::httpd, $httpd_port) unless $local_httpd;
+    my $httpd_pid = start_child('server', \&TestHTTPD::httpd, port => $httpd_port) unless $local_httpd;
 
     # Wait for proxy to load and parse config
-    wait_for_port($httpd_port);
-    wait_for_port($proxy_port);
+    wait_for_port(port => $httpd_port);
+    wait_for_port(port => $proxy_port);
 
     for (my $i = 0; $i < $workers; $i++) {
         start_child('worker', \&worker, 'localhost', '', $proxy_port, $iterations);

--- a/tests/connection_reset_test
+++ b/tests/connection_reset_test
@@ -92,8 +92,8 @@ sub main {
     my $httpd_pid = start_child('server', \&simple_server, $httpd_port);
 
     # Wait for proxy to load and parse config
-    wait_for_port($httpd_port);
-    wait_for_port($proxy_port);
+    wait_for_port(port => $httpd_port);
+    wait_for_port(port => $proxy_port);
 
     for (my $i = 0; $i < 10; $i++) {
         start_child('worker', \&bad_client, $proxy_port);

--- a/tests/fallback_test
+++ b/tests/fallback_test
@@ -86,8 +86,8 @@ sub main {
 
     my $config = make_fallback_config($proxy_port, $local_httpd || $httpd_port, $fallback_port);
     my $proxy_pid = start_child('server', \&proxy, $config, @ARGV);
-    my $httpd_pid = start_child('server', \&TestHTTPD::httpd, $httpd_port) unless $local_httpd;
-    my $fallback_httpd_pid = start_child('server', \&TestHTTPD::httpd, $fallback_port, sub {
+    my $httpd_pid = start_child('server', \&TestHTTPD::httpd, port => $httpd_port) unless $local_httpd;
+    my $fallback_httpd_pid = start_child('server', \&TestHTTPD::httpd, port => $fallback_port, generator => sub {
             return sub($) {
                 my $sock = shift;
 
@@ -102,9 +102,9 @@ sub main {
         });
 
     # Wait for proxy to load and parse config
-    wait_for_port($httpd_port);
-    wait_for_port($proxy_port);
-    wait_for_port($fallback_port);
+    wait_for_port(port => $httpd_port);
+    wait_for_port(port => $proxy_port);
+    wait_for_port(port => $fallback_port);
 
     for (my $i = 0; $i < $workers; $i++) {
         start_child('worker', \&worker, 'nonexistant.host', '', $proxy_port, $iterations);

--- a/tests/fd_limit_test
+++ b/tests/fd_limit_test
@@ -45,11 +45,11 @@ sub main {
 
     my $config = make_config($proxy_port, $local_httpd || $httpd_port);
     my $proxy_pid = start_child('server', \&proxy, $config, @ARGV);
-    my $httpd_pid = start_child('server', \&TestHTTPD::httpd, $httpd_port) unless $local_httpd;
+    my $httpd_pid = start_child('server', \&TestHTTPD::httpd, port => $httpd_port) unless $local_httpd;
 
     # Wait for proxy to load and parse config
-    wait_for_port($httpd_port);
-    wait_for_port($proxy_port);
+    wait_for_port(port => $httpd_port);
+    wait_for_port(port => $proxy_port);
 
     for (my $i = 0; $i < $workers; $i++) {
         start_child('worker', \&worker, 'localhost', '', $proxy_port, $iterations);

--- a/tests/functional_test
+++ b/tests/functional_test
@@ -76,11 +76,11 @@ sub main {
 
     my $config = make_config($proxy_port, $local_httpd || $httpd_port);
     my $proxy_pid = start_child('server', \&proxy, $config, @ARGV);
-    my $httpd_pid = start_child('server', \&TestHTTPD::httpd, $httpd_port) unless $local_httpd;
+    my $httpd_pid = start_child('server', \&TestHTTPD::httpd, port => $httpd_port) unless $local_httpd;
 
     # Wait for proxy to load and parse config
-    wait_for_port($httpd_port);
-    wait_for_port($proxy_port);
+    wait_for_port(port => $httpd_port);
+    wait_for_port(port => $proxy_port);
 
     start_child('dump-connections-worker', \&dump_connections_worker, $proxy_pid);
 

--- a/tests/hostname_test
+++ b/tests/hostname_test
@@ -69,7 +69,7 @@ sub main {
     my $proxy_pid = start_child('server', \&proxy, $config, @ARGV);
 
     # Wait for proxy to load and parse config
-    wait_for_port($proxy_port);
+    wait_for_port(port => $proxy_port);
 
     for (my $i = 0; $i < $workers; $i++) {
         start_child('worker', \&worker, $proxy_port, $iterations);

--- a/tests/reload_test
+++ b/tests/reload_test
@@ -121,12 +121,12 @@ sub main {
 
     my $config = make_config($proxy_port1, $proxy_port2, $httpd_port1);
     my $proxy_pid = start_child('server', \&proxy, $config, @ARGV);
-    my $httpd_pid = start_child('server', \&TestHTTPD::httpd, $httpd_port1);
+    my $httpd_pid = start_child('server', \&TestHTTPD::httpd, port => $httpd_port1);
 
     # Wait for proxy to load and parse config
-    wait_for_port($httpd_port1);
-    wait_for_port($proxy_port1);
-    wait_for_port($proxy_port2);
+    wait_for_port(port => $httpd_port1);
+    wait_for_port(port => $proxy_port1);
+    wait_for_port(port => $proxy_port2);
 
     for (my $i = 0; $i < $workers; $i++) {
         start_child('worker', \&worker, 'localhost', '', $proxy_port1, $iterations);
@@ -145,8 +145,8 @@ sub main {
 
     kill 1, $proxy_pid;
 
-    $httpd_pid = start_child('server', \&TestHTTPD::httpd, $httpd_port2);
-    wait_for_port($httpd_port2);
+    $httpd_pid = start_child('server', \&TestHTTPD::httpd, port => $httpd_port2);
+    wait_for_port(port => $httpd_port2);
 
     for (my $i = 0; $i < $workers; $i++) {
         start_child('worker', \&worker, 'localhost', '', $proxy_port2, $iterations);

--- a/tests/resolv_test.c
+++ b/tests/resolv_test.c
@@ -24,7 +24,7 @@ static void query_cb(struct Address *result, void *data) {
 static void
 test_init_cb(struct ev_loop *loop __attribute__((unused)), struct ev_timer *w __attribute__((unused)), int revents) {
     if (revents & EV_TIMER)
-        resolv_query("localhost", query_cb, NULL, &query_count);
+        resolv_query("localhost", RESOLV_MODE_DEFAULT, query_cb, NULL, &query_count);
 }
 
 static void

--- a/tests/slow_client_test
+++ b/tests/slow_client_test
@@ -57,11 +57,11 @@ sub main {
 
     my $config = make_config($proxy_port, $local_httpd || $httpd_port);
     my $proxy_pid = start_child('server', \&proxy, $config, @ARGV);
-    my $httpd_pid = start_child('server', \&TestHTTPD::httpd, $httpd_port) unless $local_httpd;
+    my $httpd_pid = start_child('server', \&TestHTTPD::httpd, port => $httpd_port) unless $local_httpd;
 
     # Wait for proxy to load and parse config
-    wait_for_port($httpd_port);
-    wait_for_port($proxy_port);
+    wait_for_port(port => $httpd_port);
+    wait_for_port(port => $proxy_port);
 
     for (my $i = 0; $i < $workers; $i++) {
         start_child('worker', \&slow_client, $proxy_port, $iterations);

--- a/tests/transparent_proxy_test
+++ b/tests/transparent_proxy_test
@@ -1,0 +1,171 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use TestUtils;
+use TestHTTPD;
+use File::Temp;
+
+
+sub checked_system {
+    my $result = system(@_);
+
+    if ($result == -1) {
+        die "@_ failed to execute: $!\n";
+    } elsif ($result & 127) {
+        printf STDERR "@_ died with signal %d, %s coredump\n", ($result & 127), ($result & 128) ? 'with' : 'without';
+        exit 255;
+    } elsif ($result >> 8) {
+        exit $result >> 8;
+    }
+}
+
+sub make_config($$) {
+    my $proxy_port = shift;
+    my $httpd_port = shift;
+
+    my ($fh, $filename) = File::Temp::tempfile();
+    my ($unused, $logfile) = File::Temp::tempfile();
+
+    # Write out a test config file
+    print $fh <<END;
+# Minimal test configuration
+
+user root
+
+listen 192.0.2.5 $proxy_port {
+    proto http
+    source client
+    access_log $logfile
+}
+
+table {
+    localhost 192.0.2.2 $httpd_port
+}
+END
+
+    close ($fh);
+
+    return $filename;
+}
+
+sub proxy {
+    my $config = shift;
+
+    exec('ip', 'netns', 'exec', 'ns-test-proxy', @_, '../src/sniproxy', '-f', '-c', $config);
+}
+
+sub exec_cmd {
+    exec(@_);
+}
+
+sub worker($$$$$) {
+    my ($hostname, $path, $ip, $port, $requests) = @_;
+
+    for (my $i = 0; $i < $requests; $i++) {
+        system('ip', 'netns', 'exec', 'ns-test-clt',
+                'curl',
+                '-s', '-S',
+                '-H', "Host: $hostname",
+                '-o', '/dev/null',
+                "http://$ip:$port/$path");
+
+        if ($? == -1) {
+            die "failed to execute: $!\n";
+        } elsif ($? & 127) {
+            printf STDERR "child died with signal %d, %s coredump\n", ($? & 127), ($? & 128) ? 'with' : 'without';
+            exit 255;
+        } elsif ($? >> 8) {
+            exit $? >> 8;
+        }
+    }
+    # Success
+    exit 0;
+}
+
+sub main {
+    my $proxy_port = $ENV{SNI_PROXY_PORT} || 8080;
+    my $httpd_port = $ENV{TEST_HTTPD_PORT} || 8081;
+    my $workers = $ENV{WORKERS} || 10;
+    my $iterations = $ENV{ITERATIONS} || 10;
+
+    my $config = make_config($proxy_port, $httpd_port);
+
+    die "This tests requires root privileges" unless $> == 0;
+
+    checked_system('ip', 'netns', 'add', 'ns-test-proxy');
+    checked_system('ip', 'netns', 'add', 'ns-test-clt');
+
+    checked_system('ip', 'link', 'add', 'veth-proxy-srv', 'type', 'veth', 'peer', 'name', 'veth-srv-proxy');
+
+    checked_system('ip', 'link', 'set', 'veth-srv-proxy', 'up');
+    checked_system('ip', 'addr', 'add', '192.0.2.2/30', 'dev', 'veth-srv-proxy');
+    checked_system('ip', 'route', 'add', '192.0.2.4/30', 'via', '192.0.2.1', 'dev', 'veth-srv-proxy');
+
+    checked_system('ip', 'link', 'set', 'veth-proxy-srv', 'up', 'netns', 'ns-test-proxy');
+    checked_system('ip', 'netns', 'exec', 'ns-test-proxy', 'ip', 'addr', 'add', '192.0.2.1/30', 'dev', 'veth-proxy-srv');
+
+    checked_system('ip', 'link', 'add', 'veth-proxy-clt', 'type', 'veth', 'peer', 'name', 'veth-clt-proxy');
+
+    checked_system('ip', 'link', 'set', 'veth-proxy-clt', 'up', 'netns', 'ns-test-proxy');
+    checked_system('ip', 'netns', 'exec', 'ns-test-proxy', 'ip', 'addr', 'add', '192.0.2.5/30', 'dev', 'veth-proxy-clt');
+
+    checked_system('ip', 'netns', 'exec', 'ns-test-proxy', 'sysctl', 'net.ipv4.conf.all.forwarding=1');
+    checked_system('ip', 'netns', 'exec', 'ns-test-proxy', 'iptables', '-t', 'nat', '-A', 'POSTROUTING', '-o', 'veth-proxy-clt', '-j', 'MASQUERADE');
+    checked_system('ip', 'netns', 'exec', 'ns-test-proxy', 'iptables', '-t', 'mangle', '-N', 'DIVERT');
+    checked_system('ip', 'netns', 'exec', 'ns-test-proxy', 'iptables', '-t', 'mangle', '-A', 'PREROUTING', '-p', 'tcp', '-m', 'socket', '-j', 'DIVERT');
+    checked_system('ip', 'netns', 'exec', 'ns-test-proxy', 'iptables', '-t', 'mangle', '-A', 'DIVERT', '-j', 'MARK', '--set-mark', '1');
+    checked_system('ip', 'netns', 'exec', 'ns-test-proxy', 'iptables', '-t', 'mangle', '-A', 'DIVERT', '-j', 'ACCEPT');
+    checked_system('ip', 'netns', 'exec', 'ns-test-proxy', 'ip', 'rule', 'add', 'fwmark', '1', 'lookup', '100');
+    checked_system('ip', 'netns', 'exec', 'ns-test-proxy', 'ip', 'route', 'add', 'local', '0.0.0.0/0', 'dev', 'lo', 'table', '100');
+
+    #checked_system('ip', 'netns', 'exec', 'ns-test-proxy', 'iptables-save');
+    #checked_system('ip', 'netns', 'exec', 'ns-test-proxy', 'ip', '-d', 'addr', 'show');
+    #checked_system('ip', 'netns', 'exec', 'ns-test-proxy', 'ip', '-d', 'route', 'show');
+
+    checked_system('ip', 'link', 'set', 'veth-clt-proxy', 'up', 'netns', 'ns-test-clt');
+    checked_system('ip', 'netns', 'exec', 'ns-test-clt', 'ip', 'addr', 'add', '192.0.2.6/30', 'dev', 'veth-clt-proxy');
+
+    #checked_system('ip', 'netns', 'exec', 'ns-test-clt', 'ip', '-d', 'addr', 'show');
+    #checked_system('ip', 'netns', 'exec', 'ns-test-clt', 'ip', '-d', 'route', 'show');
+
+    my $proxy_pid = start_child('proxy', \&proxy, $config, @ARGV);
+    my $httpd_pid = start_child('server', \&TestHTTPD::httpd, ip => '192.0.2.2', port => $httpd_port);
+    my $tcpdump1_pid = start_child('tcpdump', \&exec_cmd, 'ip', 'netns', 'exec', 'ns-test-proxy', 'tcpdump', '-npi' ,'veth-proxy-clt', '-s', '0', '-w', 'veth-proxy-clt.pcap');
+    my $tcpdump2_pid = start_child('tcpdump', \&exec_cmd, 'ip', 'netns', 'exec', 'ns-test-proxy', 'tcpdump', '-npi' ,'veth-proxy-srv', '-s', '0', '-w', 'veth-proxy-srv.pcap');
+
+    #checked_system('ip', 'netns', 'exec', 'ns-test-proxy', 'ss', '-lptn');
+
+    # Wait for proxy to load and parse config
+    wait_for_port(ip => '192.0.2.2', port => $httpd_port);
+    wait_for_port(ip => '192.0.2.5', port => $proxy_port);
+
+    for (my $i = 0; $i < $workers; $i++) {
+        start_child('worker', \&worker, 'localhost', '', '192.0.2.5', $proxy_port, $iterations);
+    }
+
+    # Wait for all our children to finish
+    wait_for_type('worker');
+
+    # Give the proxy a second to flush buffers and close server connections
+    sleep 1;
+
+    # Orderly shutdown of the server
+    kill 15, $proxy_pid;
+    kill 15, $httpd_pid;
+    kill 15, $tcpdump1_pid;
+    kill 15, $tcpdump2_pid;
+    sleep 1;
+
+    # Delete our test configuration
+    unlink($config);
+
+    # Kill off any remaining children
+    reap_children();
+
+    # Cleanup our network name spaces
+    checked_system('ip', 'netns', 'delete', 'ns-test-clt');
+    checked_system('ip', 'netns', 'delete', 'ns-test-proxy');
+}
+
+main();

--- a/tests/wildcard_test
+++ b/tests/wildcard_test
@@ -75,7 +75,7 @@ sub main {
     my $proxy_pid = start_child('server', \&proxy, $config, @ARGV);
 
     # Wait for proxy to load and parse config
-    wait_for_port($proxy_port);
+    wait_for_port(port => $proxy_port);
 
     for (my $i = 0; $i < $workers; $i++) {
         start_child('worker', \&worker, $proxy_port, $iterations);


### PR DESCRIPTION
Adding transparent proxy support previously discussed in issue #179. This PR adds a `source client` listener directive which enables transparent proxy support on Linux, but requires running sniproxy as root. A follow on PR will use capabilities(7) for more fine grain privilege control.

The following need to be in place before considering merging this feature:
- [x] Functional test
- [x] Handle cross address family corner cases
- [x] Don't break systems which lack IP_TRANSPARENT