### PR TITLE
Implement dropping group privileges

### DIFF
--- a/sniproxy.conf
+++ b/sniproxy.conf
@@ -3,6 +3,7 @@
 # lines with only white space are ignored
 
 user nobody
+group nogroup
 
 # PID file, needs to be placed in directory writable by user
 pidfile /var/tmp/sniproxy.pid

--- a/src/config.c
+++ b/src/config.c
@@ -38,6 +38,7 @@ struct LoggerBuilder {
 };
 
 static int accept_username(struct Config *, char *);
+static int accept_groupname(struct Config *, char *);
 static int accept_pidfile(struct Config *, char *);
 static int end_listener_stanza(struct Config *, struct Listener *);
 static int end_table_stanza(struct Config *, struct Table *);
@@ -146,6 +147,11 @@ static struct Keyword global_grammar[] = {
             (int(*)(void *, char *))accept_username,
             NULL,
             NULL},
+    { "groupname",
+            NULL,
+            (int(*)(void *, char *))accept_groupname,
+            NULL,
+            NULL},
     { "pidfile",
             NULL,
             (int(*)(void *, char *))accept_pidfile,
@@ -198,6 +204,7 @@ init_config(const char *filename, struct ev_loop *loop) {
 
     config->filename = NULL;
     config->user = NULL;
+    config->group = NULL;
     config->pidfile = NULL;
     config->access_log = NULL;
     config->resolver.nameservers = NULL;
@@ -253,6 +260,7 @@ void
 free_config(struct Config *config, struct ev_loop *loop) {
     free(config->filename);
     free(config->user);
+    free(config->group);
     free(config->pidfile);
 
     free_string_vector(config->resolver.nameservers);
@@ -318,6 +326,17 @@ static int
 accept_username(struct Config *config, char *username) {
     config->user = strdup(username);
     if (config->user == NULL) {
+        err("%s: strdup", __func__);
+        return -1;
+    }
+
+    return 1;
+}
+
+static int
+accept_groupname(struct Config *config, char *groupname) {
+    config->group = strdup(groupname);
+    if (config->group == NULL) {
         err("%s: strdup", __func__);
         return -1;
     }

--- a/src/config.h
+++ b/src/config.h
@@ -33,6 +33,7 @@
 struct Config {
     char *filename;
     char *user;
+    char *group;
     char *pidfile;
     struct ResolverConfig {
         char **nameservers;

--- a/src/sniproxy.c
+++ b/src/sniproxy.c
@@ -224,7 +224,7 @@ drop_perms(const char *username, const char *groupname) {
 
     gid_t gid = user->pw_gid;
 
-    if (groupname) {
+    if (groupname != NULL) {
       errno = 0;
       struct group *group = getgrnam(groupname);
       if (errno)


### PR DESCRIPTION
This PR adds support for running sniproxy as a different group than the primary group set with the `user` configuration option. A `group` option can now be used in the config-file.

If no group is provided, the user's default group is used.