### PR TITLE
accept4 needs SOCK_NONBLOCK as flag

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -111,7 +111,7 @@ accept_connection(struct Listener *listener, struct ev_loop *loop) {
     int sockfd = accept4(listener->watcher.fd,
                     (struct sockaddr *)&con->client.addr,
                     &con->client.addr_len,
-                    O_NONBLOCK);
+                    SOCK_NONBLOCK);
 #else
     int sockfd = accept(listener->watcher.fd,
                     (struct sockaddr *)&con->client.addr,


### PR DESCRIPTION
On Linux SOCK_NONBLOCK and O_NONBLOCK have the same value, so the code works by accident.
On other systems (like illumos) this is not the case and will result in errors:
```
accept failed: Invalid argument
```



