### PR TITLE
Feature: include PROXY v1 header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   - bash -c "cd tests && ./wildcard_test valgrind --leak-check=full --error-exitcode=1"
   - bash -c "cd tests && ./bind_source_test valgrind --leak-check=full --error-exitcode=1"
   - bash -c "cd tests && ./reload_test valgrind --leak-check=full --error-exitcode=1"
+  - bash -c "cd tests && ./proxy_header_test valgrind --leak-check=full --error-exitcode=1"
   - echo "Testing Debian package build"
   - dpkg-buildpackage -us -uc
   - echo "Testing RPM package build"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Features
 + Supports IPv4, IPv6 and Unix domain sockets for both back end servers and
   listeners.
 + Supports multiple listening sockets per instance.
++ Supports HAProxy proxy protocol to propagate original source address to
+  backend servers.
 
 Usage
 -----

--- a/man/sniproxy.conf.5
+++ b/man/sniproxy.conf.5
@@ -182,7 +182,7 @@ The access log configuration may be overridden on each listener.
 table http_hosts {
     ^example\\.com$ 192.0.2.101
     ^example\\.net$ 192.0.2.102
-    ^example\\.org$ 192.0.2.103
+    ^example\\.org$ 192.0.2.103 proxy_protocol
 }
 .fi
 .PP
@@ -192,6 +192,10 @@ hostname is matched against entries in the table in order, until a match is
 found and that server is used. The server address may be either IP, an IP and
 port, a unix socket path, a hostname or '*'. If no port is specified, the port
 of the listener which connection was received on will be used.
+
+The optional proxy_protocol option will prepend a HAProxy PROXY v1 protocol
+header to the proxied connection allowing supporting webservers to obtain the
+source and destination IP and port of the original incoming TCP connection.
 
 
 .SH "SEE ALSO"

--- a/sniproxy.conf
+++ b/sniproxy.conf
@@ -118,7 +118,7 @@ listen unix:/var/run/proxy.sock {
 table http_hosts {
     example.com 192.0.2.10:8001
     example.net 192.0.2.10:8002
-    example.org 192.0.2.10:8003
+    example.org 192.0.2.10:8003 proxy_protocol
 
 # Each table entry is composed of three parts:
 #

--- a/src/backend.c
+++ b/src/backend.c
@@ -35,6 +35,7 @@
 
 
 static void free_backend(struct Backend *);
+static char *backend_config_options(const struct Backend *);
 
 
 struct Backend *
@@ -139,9 +140,18 @@ void
 print_backend_config(FILE *file, const struct Backend *backend) {
     char address[ADDRESS_BUFFER_SIZE];
 
-    fprintf(file, "\t%s %s\n",
+    fprintf(file, "\t%s %s%s\n",
             backend->pattern,
-            display_address(backend->address, address, sizeof(address)));
+            display_address(backend->address, address, sizeof(address)),
+            backend_config_options(backend));
+}
+
+static char *
+backend_config_options(const struct Backend *backend) {
+    if (backend->use_proxy_header)
+        return " proxy";
+    else
+        return "";
 }
 
 void

--- a/src/backend.c
+++ b/src/backend.c
@@ -76,6 +76,9 @@ accept_backend_arg(struct Backend *backend, const char *arg) {
             err("Invalid port: %s", arg);
             return -1;
         }
+    } else if (backend->use_proxy_header == 0 &&
+        strcasecmp(arg, "proxy") == 0) {
+        backend->use_proxy_header = 1;
     } else {
         err("Unexpected table backend argument: %s", arg);
         return -1;

--- a/src/backend.c
+++ b/src/backend.c
@@ -78,7 +78,7 @@ accept_backend_arg(struct Backend *backend, const char *arg) {
             return -1;
         }
     } else if (backend->use_proxy_header == 0 &&
-        strcasecmp(arg, "proxy") == 0) {
+        strcasecmp(arg, "proxy_protocol") == 0) {
         backend->use_proxy_header = 1;
     } else {
         err("Unexpected table backend argument: %s", arg);
@@ -149,7 +149,7 @@ print_backend_config(FILE *file, const struct Backend *backend) {
 static char *
 backend_config_options(const struct Backend *backend) {
     if (backend->use_proxy_header)
-        return " proxy";
+        return " proxy_protocol";
     else
         return "";
 }

--- a/src/backend.h
+++ b/src/backend.h
@@ -36,6 +36,7 @@ STAILQ_HEAD(Backend_head, Backend);
 struct Backend {
     char *pattern;
     struct Address *address;
+    int use_proxy_header;
 
     /* Runtime fields */
     pcre *pattern_re;

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -227,7 +227,8 @@ buffer_peek(const struct Buffer *src, void *dst, size_t len) {
     size_t iov_len = setup_read_iov(src, iov, len);
 
     for (size_t i = 0; i < iov_len; i++) {
-        memcpy((char *)dst + bytes_copied, iov[i].iov_base, iov[i].iov_len);
+        if (dst != NULL)
+            memcpy((char *)dst + bytes_copied, iov[i].iov_base, iov[i].iov_len);
 
         bytes_copied += iov[i].iov_len;
     }

--- a/src/config.c
+++ b/src/config.c
@@ -411,6 +411,8 @@ static int
 end_backend(struct Table *table, struct Backend *backend) {
     /* TODO check backend */
 
+    table->use_proxy_header = table->use_proxy_header ||
+                              backend->use_proxy_header;
     add_backend(&table->backends, backend);
 
     return 1;

--- a/src/connection.c
+++ b/src/connection.c
@@ -139,7 +139,7 @@ accept_connection(struct Listener *listener, struct ev_loop *loop) {
 
     ev_io_start(loop, client_watcher);
 
-    if (0 /* TODO: test if proxy is enabled on this backend */) {
+    if (con->listener->table->use_proxy_header) {
         struct sockaddr_storage dest_addr;
         socklen_t dest_addr_len = sizeof(dest_addr);
         char ip[INET6_ADDRSTRLEN] = { '\0' };

--- a/src/connection.c
+++ b/src/connection.c
@@ -140,7 +140,8 @@ accept_connection(struct Listener *listener, struct ev_loop *loop) {
 
     ev_io_start(loop, client_watcher);
 
-    if (con->listener->table->use_proxy_header) {
+    if (con->listener->table->use_proxy_header ||
+            con->listener->fallback_use_proxy_header) {
         struct sockaddr_storage dest_addr;
         socklen_t dest_addr_len = sizeof(dest_addr);
         char ip[INET6_ADDRSTRLEN] = { '\0' };

--- a/src/connection.h
+++ b/src/connection.h
@@ -46,8 +46,8 @@ struct Connection {
     } state;
 
     struct {
-        struct sockaddr_storage addr;
-        socklen_t addr_len;
+        struct sockaddr_storage addr, local_addr;
+        socklen_t addr_len, local_addr_len;
         struct ev_io watcher;
         struct Buffer *buffer;
     } client, server;

--- a/src/connection.h
+++ b/src/connection.h
@@ -54,6 +54,7 @@ struct Connection {
     struct Listener *listener;
     const char *hostname; /* Requested hostname */
     size_t hostname_len;
+    size_t header_len;
     struct ResolvQuery *query_handle;
     ev_tstamp established_timestamp;
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -57,6 +57,7 @@ struct Connection {
     size_t header_len;
     struct ResolvQuery *query_handle;
     ev_tstamp established_timestamp;
+    int use_proxy_header;
 
     TAILQ_ENTRY(Connection) entries;
 };

--- a/src/listener.h
+++ b/src/listener.h
@@ -40,6 +40,7 @@ struct Listener {
     char *table_name;
     struct Logger *access_log;
     int log_bad_requests, reuseport, transparent_proxy, ipv6_v6only;
+    int fallback_use_proxy_header;
 
     /* Runtime fields */
     int reference_count;

--- a/src/listener.h
+++ b/src/listener.h
@@ -67,7 +67,7 @@ void remove_listener(struct Listener_head *, struct Listener *, struct ev_loop *
 void free_listeners(struct Listener_head *, struct ev_loop *);
 
 int valid_listener(const struct Listener *);
-struct Address *listener_lookup_server_address(const struct Listener *,
+struct LookupResult listener_lookup_server_address(const struct Listener *,
         const char *, size_t);
 void print_listener_config(FILE *, const struct Listener *);
 void listener_ref_put(struct Listener *);

--- a/src/table.c
+++ b/src/table.c
@@ -59,6 +59,7 @@ new_table() {
     }
 
     table->name = NULL;
+    table->use_proxy_header = 0;
     table->reference_count = 0;
     STAILQ_INIT(&table->backends);
 

--- a/src/table.c
+++ b/src/table.c
@@ -128,17 +128,16 @@ remove_table(struct Table_head *tables, struct Table *table) {
     table_ref_put(table);
 }
 
-const struct Address *
+struct LookupResult
 table_lookup_server_address(const struct Table *table, const char *name, size_t name_len) {
-    struct Backend *b;
-
-    b = table_lookup_backend(table, name, name_len);
+    struct Backend *b = table_lookup_backend(table, name, name_len);
     if (b == NULL) {
         info("No match found for %.*s", (int)name_len, name);
-        return NULL;
+        return (struct LookupResult){.address = NULL};
     }
 
-    return b->address;
+    return (struct LookupResult){.address = b->address,
+                                 .use_proxy_header = b->use_proxy_header};
 }
 
 void

--- a/src/table.h
+++ b/src/table.h
@@ -37,6 +37,7 @@ SLIST_HEAD(Table_head, Table);
 
 struct Table {
     char *name;
+    int use_proxy_header;
 
     /* Runtime fields */
     int reference_count;

--- a/src/table.h
+++ b/src/table.h
@@ -45,12 +45,18 @@ struct Table {
     SLIST_ENTRY(Table) entries;
 };
 
+struct LookupResult {
+    const struct Address *address;
+    int caller_free_address;
+    int use_proxy_header;
+};
+
 struct Table *new_table();
 int accept_table_arg(struct Table *, const char *);
 void add_table(struct Table_head *, struct Table *);
 struct Table *table_lookup(const struct Table_head *, const char *);
-const struct Address *table_lookup_server_address(const struct Table *,
-                                                  const char *, size_t);
+struct LookupResult table_lookup_server_address(const struct Table *,
+                                                const char *, size_t);
 void reload_tables(struct Table_head *, struct Table_head *);
 void print_table_config(FILE *, struct Table *);
 int valid_table(struct Table *);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,7 +16,8 @@ TESTS = http_test \
         bind_source_test \
         fd_limit_test \
 		reuseport_test \
-		ipv6_v6only_test
+		ipv6_v6only_test \
+		proxy_header_test
 
 if DNS_ENABLED
   TESTS += config_test \

--- a/tests/TestHTTPD.pm
+++ b/tests/TestHTTPD.pm
@@ -10,6 +10,35 @@ our @ISA = qw(Exporter);
 our @EXPORT = qw(new);
 our $VERSION = '0.01';
 
+my $http_methods = {
+    'GET' => 1,
+    'POST' => 1,
+    'HEAD' => 1,
+    'PUT' => 1,
+    'DELETE' => 1,
+    'TRACE' => 1,
+    'DEBUG' => 1,
+    'CONNECT' => 1,
+    'OPTIONS' => 1,
+};
+
+
+sub default_response_parser {
+    my $sock = shift;
+    my $status = 500;
+
+    # Read HTTP request
+    for (my $i = 0; my $line = $sock->getline(); $i++) {
+        if ($i == 0 && $line =~ m/\A(\S+) (\S+) HTTP\/(\S+)\r\n\z/) {
+            $status = 200 if exists($http_methods->{$1});
+        }
+
+        # Wait for blank line indicating the end of the request
+        last if $i > 0 && $line eq "\r\n";
+    }
+
+    return $status;
+};
 
 my $count = 0;
 
@@ -22,17 +51,24 @@ my $responses = [
     [ 20, 1, 1, 1, 1, 1, 1, 200 ],
 ];
 
+my $http_status_line = {
+    200 => 'OK',
+    203 => 'Non-Authoritative Information',
+    500 => 'Internal Server Error',
+};
+
 sub default_response_generator {
     $count ++;
 
-    return sub($) {
+    return sub($$) {
         my $sock = shift;
+        my $status = shift;
 
         my @chunks = @{$responses->[$count % scalar @{$responses}]};
         my $content_length = 0;
         map { $content_length += $_ } @chunks;
 
-        print $sock "HTTP/1.1 200 OK\r\n";
+        print $sock "HTTP/1.1 $status " . $http_status_line->{$status} . "\r\n";
         print $sock "Server: TestHTTPD/$VERSION\r\n";
         print $sock "Content-Type: text/plain\r\n";
         print $sock "Content-Length: $content_length\r\n";
@@ -52,6 +88,7 @@ sub httpd {
     my %args = @_;
     my $ip = $args{'ip'} || 'localhost';
     my $port = $args{'port'} || 8081;
+    my $request_parser = $args{'parser'} || \&default_response_parser;
     my $responder_generator = $args{'generator'} || \&default_response_generator;
 
     my $server = IO::Socket::INET->new(Listen    => Socket::SOMAXCONN(),
@@ -72,14 +109,10 @@ sub httpd {
 
         # Child
         #
-        # Read HTTP request
-        while (my $line = $client->getline()) {
-            # Wait for blank line indicating the end of the request
-            last if $line eq "\r\n";
-        }
+        my $status = $request_parser->($client);
 
         # Assume a GET request
-        $responder->($client);
+        $responder->($client, $status);
 
         $client->close();
         exit 0;

--- a/tests/fallback_test
+++ b/tests/fallback_test
@@ -90,8 +90,9 @@ sub main {
     my $proxy_pid = start_child('server', \&proxy, $config, @ARGV);
     my $httpd_pid = start_child('server', \&TestHTTPD::httpd, port => $httpd_port) unless $local_httpd;
     my $fallback_httpd_pid = start_child('server', \&TestHTTPD::httpd, port => $fallback_port, generator => sub {
-            return sub($) {
+            return sub($$) {
                 my $sock = shift;
+                my $status = shift;
 
                 print $sock "HTTP/1.1 203 Non-Authoritative Information\r\n";
                 print $sock "Server: TestHTTPD/$TestHTTPD::VERSION\r\n";

--- a/tests/proxy_header_test
+++ b/tests/proxy_header_test
@@ -33,7 +33,7 @@ listen 127.0.0.1 $proxy_port {
 }
 
 table {
-    transparent.local 127.0.0.1:$httpd2_port proxy
+    proxy-protocol.local 127.0.0.1:$httpd2_port proxy_protocol
     localhost 127.0.0.1:$httpd_port
 }
 END
@@ -110,7 +110,7 @@ sub main {
     wait_for_port(port => $proxy_port);
 
     for (my $i = 0; $i < $workers; $i++) {
-        my $req_hostname = ($i % 2) ? 'transparent.local' : 'localhost';
+        my $req_hostname = ($i % 2) ? 'proxy-protocol.local' : 'localhost';
         start_child('worker', \&worker, $req_hostname, '', $proxy_port, $iterations);
     }
 

--- a/tests/proxy_header_test
+++ b/tests/proxy_header_test
@@ -1,0 +1,136 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use File::Basename;
+use lib dirname (__FILE__);
+use TestUtils;
+use TestHTTPD;
+use File::Temp;
+use IO::Socket::INET;
+
+sub proxy {
+    my $config = shift;
+
+    exec(@_, '../src/sniproxy', '-f', '-c', $config);
+}
+
+sub make_proxy_config($$$) {
+    my $proxy_port = shift;
+    my $httpd_port = shift;
+    my $httpd2_port = shift;
+
+    my ($fh, $filename) = File::Temp::tempfile();
+    my ($unused, $logfile) = File::Temp::tempfile();
+
+    # Write out a test config file
+    print $fh <<END;
+# Minimal fallback test configuration
+
+listen 127.0.0.1 $proxy_port {
+    proto http
+    access_log $logfile
+}
+
+table {
+    transparent.local 127.0.0.1:$httpd2_port proxy
+    localhost 127.0.0.1:$httpd_port
+}
+END
+
+    close ($fh);
+
+    return $filename;
+}
+
+sub worker($$$$) {
+    my ($hostname, $path, $port, $requests) = @_;
+
+    for (my $i = 0; $i < $requests; $i++) {
+        system('curl',
+                '-s', '-S',
+                '--fail',
+                '-H', "Host: $hostname",
+                '-o', '/dev/null',
+                "http://localhost:$port/$path");
+
+        if ($? == -1) {
+            die "failed to execute: $!\n";
+        } elsif ($? & 127) {
+            printf STDERR "child died with signal %d, %s coredump\n", ($? & 127), ($? & 128) ? 'with' : 'without';
+            exit 255;
+        } elsif ($? >> 8) {
+            exit $? >> 8;
+        }
+    }
+    # Success
+    exit 0;
+}
+
+sub valid_port($) {
+    my $port = shift;
+
+    return $port eq int($port) && $port > 0 && $port <= 65535;
+}
+
+sub main {
+    my $proxy_port = $ENV{SNI_PROXY_PORT} || 8080;
+    my $httpd_port = $ENV{TEST_HTTPD_PORT} || 8081;
+    my $httpd2_port = $ENV{TEST_HTTPD_PORT2} || 8082;
+    my $workers = $ENV{WORKERS} || 10;
+    my $iterations = $ENV{ITERATIONS} || 10;
+    my $local_httpd = $ENV{LOCAL_HTTPD_PORT};
+
+    my $config = make_proxy_config($proxy_port, $local_httpd || $httpd_port, $httpd2_port);
+    my $proxy_pid = start_child('server', \&proxy, $config, @ARGV);
+    my $httpd_pid = start_child('server', \&TestHTTPD::httpd, port => $httpd_port) unless $local_httpd;
+    my $httpd2_pid = start_child('server', \&TestHTTPD::httpd, port => $httpd2_port, parser => sub {
+        my $sock = shift;
+
+        my $status = 500;
+
+        for (my $i = 0; my $line = $sock->getline(); $i++) {
+            if ($i == 0 && $line =~ m/\APROXY (\S+) (\S+) (\S+) (\S+) (\S+)\r\n\z/ &&
+                $1 eq 'TCP4' &&
+                $2 eq '127.0.0.1' && $3 eq '127.0.0.1' &&
+                valid_port($4) && valid_port($5)) {
+                $status = 200;
+            }
+
+            # Wait for blank line indicating the end of the request
+            last if $line eq "\r\n";
+        }
+
+        return $status;
+    });
+
+    # Wait for proxy to load and parse config
+    wait_for_port(port => $httpd_port);
+    wait_for_port(port => $httpd2_port);
+    wait_for_port(port => $proxy_port);
+
+    for (my $i = 0; $i < $workers; $i++) {
+        my $req_hostname = ($i % 2) ? 'transparent.local' : 'localhost';
+        start_child('worker', \&worker, $req_hostname, '', $proxy_port, $iterations);
+    }
+
+    # Wait for all our children to finish
+    wait_for_type('worker');
+
+    # Give the proxy a second to flush buffers and close server connections
+    sleep 1;
+
+    # Orderly shutdown of the server
+    kill 15, $proxy_pid;
+    kill 15, $httpd_pid unless $local_httpd;
+    kill 15, $httpd2_pid;
+    sleep 1;
+
+    # Delete our test configuration
+    unlink($config);
+
+    # Kill off any remaining children
+    reap_children();
+}
+
+main();

--- a/tests/table_test.c
+++ b/tests/table_test.c
@@ -36,8 +36,9 @@ test_empty_table() {
     assert(name != table->name);
 
     const char *server_query = "example.com";
-    assert(table_lookup_server_address(table, server_query,
-            strlen(server_query)) == NULL);
+    struct LookupResult result = table_lookup_server_address(table,
+            server_query, strlen(server_query));
+    assert(result.address == NULL);
 
     table_ref_put(table);
 }
@@ -72,8 +73,9 @@ test_single_entry_table() {
     init_table(table);
 
     const char *server_query = "example.com";
-    assert(table_lookup_server_address(table, server_query,
-            strlen(server_query)) != NULL);
+    struct LookupResult result = table_lookup_server_address(table,
+            server_query, strlen(server_query));
+    assert(result.address != NULL);
 
     table_ref_put(table);
 }


### PR DESCRIPTION
Initial proxy header support. Any testing reports and code review would be appreciated.

- [x] update README
- [x] update man page
- [x] add proxy option to listener fallback address (if this would be useful)
- [x] consider persisting local client socket object (see also #269)
- [x] test  well formed proxy header is received
- [x] test including table with proxy enabled on one unused backend to ensure proxy header is stripped properly 
- [x] valgrind testing all of the above cases since this increases complexity of address object deallocation

Related #171, #247, #274