### PR TITLE
While porting sniproxy to FreeBSD, I've notice wrong location of PID

### DIFF
--- a/sniproxy.conf
+++ b/sniproxy.conf
@@ -6,7 +6,7 @@ user nobody
 group nogroup
 
 # PID file, needs to be placed in directory writable by user
-pidfile /var/tmp/sniproxy.pid
+pidfile /var/run/sniproxy.pid
 
 # The DNS resolver is required for tables configured using wildcard or hostname
 # targets. If no resolver is specified, the nameserver and search domain are


### PR DESCRIPTION
file. Move PID to /var/run as mentioned in man page.