### PR TITLE
Fixed formatting type mismatch for size_t.

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -448,7 +448,7 @@ parse_client_request(struct Connection *con) {
             if (buffer_room(con->client.buffer) > 0)
                 return; /* give client a chance to send more data */
 
-            warn("Request from %s exceeded %ld byte buffer size",
+            warn("Request from %s exceeded %zu byte buffer size",
                     display_sockaddr(&con->client.addr, client, sizeof(client)),
                     buffer_size(con->client.buffer));
         } else if (result == -2) {
@@ -843,7 +843,7 @@ log_connection(struct Connection *con) {
 
     log_msg(con->listener->access_log,
            LOG_NOTICE,
-           "%s -> %s -> %s [%.*s] %ld/%ld bytes tx %ld/%ld bytes rx %1.3f seconds",
+           "%s -> %s -> %s [%.*s] %zu/%zu bytes tx %zu/%zu bytes rx %1.3f seconds",
            client_address,
            listener_address,
            server_address,
@@ -875,7 +875,7 @@ log_bad_request(struct Connection *con __attribute__((unused)), const char *req,
                                 "0x%02hhx, ", (unsigned char)req[i]);
 
     message_pos -= 2;/* Delete the trailing ', ' */
-    snprintf(message_pos, (size_t)(message_end - message_pos), "}, %ld, ...) = %d",
+    snprintf(message_pos, (size_t)(message_end - message_pos), "}, %zu, ...) = %d",
              req_len, parse_result);
     debug("%s", message);
 


### PR DESCRIPTION
The `size_t` has `printf` size equivalent `%zu` (`size_t`-sized unsigned), so use it instead of `%ld`, which is wrong on size (32bit CPU has 32bit `size_t`) and signedness (`%d` is signed, while `size_t` is unsigned, so should be `%u`).