### PR TITLE
Enable TCP keepalive on the listen socket

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -660,14 +660,6 @@ initiate_server_connect(struct Connection *con, struct ev_loop *loop) {
             return;
         }
 
-        result = setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on));
-        if (result < 0) {
-            err("setsockopt SO_KEEPALIVE failed: %s", strerror(errno));
-            close(sockfd);
-            abort_connection(con);
-            return;
-        }
-
         int tries = 5;
         do {
             result = bind(sockfd,

--- a/src/connection.c
+++ b/src/connection.c
@@ -660,6 +660,14 @@ initiate_server_connect(struct Connection *con, struct ev_loop *loop) {
             return;
         }
 
+        result = setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on));
+        if (result < 0) {
+            err("setsockopt SO_KEEPALIVE failed: %s", strerror(errno));
+            close(sockfd);
+            abort_connection(con);
+            return;
+        }
+
         int tries = 5;
         do {
             result = bind(sockfd,

--- a/src/listener.c
+++ b/src/listener.c
@@ -524,6 +524,15 @@ init_listener(struct Listener *listener, const struct Table_head *tables,
         return result;
     }
 
+    /* set SO_KEEPALIVE on the server socket so that abandoned client connections
+     * do not linger behind forever */
+    result = setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on));
+    if (result < 0) {
+        err("setsockopt SO_KEEPALIVE failed: %s", strerror(errno));
+        close(sockfd);
+        return result;
+    }
+
     if (listener->reuseport == 1) {
 #ifdef SO_REUSEPORT
         /* set SO_REUSEPORT on server socket to allow binding of multiple


### PR DESCRIPTION
Without using TCP keepalive, client connections that are not closed
correctly linger behind forever, eventually exhausting the open files
limit, causing new connections to fail.