### PR TITLE
transparent proxy: use IP_BINDANY where available

### DIFF
--- a/src/listener.c
+++ b/src/listener.c
@@ -376,7 +376,7 @@ accept_listener_source_address(struct Listener *listener, const char *source) {
     }
 
     if (strcasecmp("client", source) == 0) {
-#ifdef IP_TRANSPARENT
+#if defined(IP_TRANSPARENT) || defined(IP_BINDANY) && defined(IPV6_BINDANY)
         listener->transparent_proxy = 1;
         return 1;
 #else


### PR DESCRIPTION
This should add transparent proxy support for FreeBSD. I've tested this builds on FreeBSD 12.0, but I'm not sure if there are similar firewall considerations as there in on Linux: https://github.com/dlundquist/sniproxy/blob/87461aa81bfcdac4d3ee65a8553db0f1b04945be/tests/transparent_proxy_test#L101-L157. If someone wants to make transparent_proxy_test work on FreeBSD too that would be great.

See issue #315.