### PR TITLE
TCP Fast Open support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.60])
-AC_INIT([sniproxy], [0.6.0+git.14.g136934f])
+AC_INIT([sniproxy], [0.6.0+git.15.g078fad8])
 AC_CONFIG_SRCDIR([src/sniproxy.c])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.60])
-AC_INIT([sniproxy], [0.6.0])
+AC_INIT([sniproxy], [0.6.0+git.10.g6fd682d])
 AC_CONFIG_SRCDIR([src/sniproxy.c])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.60])
-AC_INIT([sniproxy], [0.6.0+git.10.g6fd682d])
+AC_INIT([sniproxy], [0.6.0+git.11.g1a8a445])
 AC_CONFIG_SRCDIR([src/sniproxy.c])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.60])
-AC_INIT([sniproxy], [0.6.0+git.12.g054fd40])
+AC_INIT([sniproxy], [0.6.0+git.13.ga01050e])
 AC_CONFIG_SRCDIR([src/sniproxy.c])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.60])
-AC_INIT([sniproxy], [0.6.0+git.11.g1a8a445])
+AC_INIT([sniproxy], [0.6.0+git.12.g054fd40])
 AC_CONFIG_SRCDIR([src/sniproxy.c])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.60])
-AC_INIT([sniproxy], [0.6.0+git.13.ga01050e])
+AC_INIT([sniproxy], [0.6.0+git.14.g136934f])
 AC_CONFIG_SRCDIR([src/sniproxy.c])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/redhat/sniproxy.spec
+++ b/redhat/sniproxy.spec
@@ -1,5 +1,5 @@
 Name: sniproxy
-Version: 0.6.0
+Version: 0.6.0+git.10.g6fd682d
 Release: 1%{?dist}
 Summary: Transparent TLS and HTTP layer 4 proxy with SNI support
 

--- a/redhat/sniproxy.spec
+++ b/redhat/sniproxy.spec
@@ -1,5 +1,5 @@
 Name: sniproxy
-Version: 0.6.0+git.14.g136934f
+Version: 0.6.0+git.15.g078fad8
 Release: 1%{?dist}
 Summary: Transparent TLS and HTTP layer 4 proxy with SNI support
 

--- a/redhat/sniproxy.spec
+++ b/redhat/sniproxy.spec
@@ -1,5 +1,5 @@
 Name: sniproxy
-Version: 0.6.0+git.11.g1a8a445
+Version: 0.6.0+git.12.g054fd40
 Release: 1%{?dist}
 Summary: Transparent TLS and HTTP layer 4 proxy with SNI support
 

--- a/redhat/sniproxy.spec
+++ b/redhat/sniproxy.spec
@@ -1,5 +1,5 @@
 Name: sniproxy
-Version: 0.6.0+git.12.g054fd40
+Version: 0.6.0+git.13.ga01050e
 Release: 1%{?dist}
 Summary: Transparent TLS and HTTP layer 4 proxy with SNI support
 

--- a/redhat/sniproxy.spec
+++ b/redhat/sniproxy.spec
@@ -1,5 +1,5 @@
 Name: sniproxy
-Version: 0.6.0+git.10.g6fd682d
+Version: 0.6.0+git.11.g1a8a445
 Release: 1%{?dist}
 Summary: Transparent TLS and HTTP layer 4 proxy with SNI support
 

--- a/redhat/sniproxy.spec
+++ b/redhat/sniproxy.spec
@@ -1,5 +1,5 @@
 Name: sniproxy
-Version: 0.6.0+git.13.ga01050e
+Version: 0.6.0+git.14.g136934f
 Release: 1%{?dist}
 Summary: Transparent TLS and HTTP layer 4 proxy with SNI support
 

--- a/src/config.c
+++ b/src/config.c
@@ -106,6 +106,10 @@ static const struct Keyword listener_stanza_grammar[] = {
         .parse_arg=(int(*)(void *, const char *))accept_listener_reuseport,
     },
     {
+        .keyword="fastopen",
+        .parse_arg=(int(*)(void *, const char *))accept_listener_fastopen,
+    },
+    {
         .keyword="ipv6_v6only",
         .parse_arg=(int(*)(void *, const char *))accept_listener_ipv6_v6only,
     },

--- a/src/connection.c
+++ b/src/connection.c
@@ -699,14 +699,16 @@ initiate_server_connect(struct Connection *con, struct ev_loop *loop) {
     }
 
     /* TODO TCP Fast Open killswitch */
-    con->fast_open = 1;
+    con->server.fast_open = 1;
 
-    if (con->fast_open) {
-#ifdef MSG_FASTOPEN
-        con->server.addr_once = (struct sockaddr *)&con->server.addr;
-#else
-        warn("TCP Fast Open not supported");
+#ifndef MSG_FASTOPEN
+    con->server.fast_open = 0;
+    con->server.addr_once = NULL;
+    warn("TCP Fast Open not supported");
 #endif
+
+    if (con->server.fast_open) {
+        con->server.addr_once = (struct sockaddr *)&con->server.addr;
     } else {
         result = connect(sockfd,
                 (struct sockaddr *)&con->server.addr,

--- a/src/connection.c
+++ b/src/connection.c
@@ -699,16 +699,14 @@ initiate_server_connect(struct Connection *con, struct ev_loop *loop) {
         }
     }
 
-    /* TODO TCP Fast Open killswitch */
-    con->server.fast_open = 1;
-
 #ifndef MSG_FASTOPEN
-    con->server.fast_open = 0;
+    con->listener->fastopen = 0;
     con->server.addr_once = NULL;
-    warn("TCP Fast Open not supported");
+    warn("TCP Fast Open for client sockets not supported in this build");
 #endif
 
-    if (con->server.fast_open) {
+    if (con->listener->fastopen == 1 || 
+        con->listener->fastopen == 3) {
         con->server.addr_once = (struct sockaddr *)&con->server.addr;
     } else {
         result = connect(sockfd,

--- a/src/connection.c
+++ b/src/connection.c
@@ -255,7 +255,8 @@ connection_cb(struct ev_loop *loop, struct ev_io *w, int revents) {
     if (revents & EV_READ && buffer_room(input_buffer)) {
         ssize_t bytes_received = buffer_recv(input_buffer, w->fd, 0, loop);
         if (bytes_received < 0 && 
-            !IS_TEMPORARY_SOCKERR(errno) && !con->server.addr_once) {
+            !IS_TEMPORARY_SOCKERR(errno) && 
+            !con->server.addr_once) {
             warn("recv(%s): %s, closing connection",
                     socket_name,
                     strerror(errno));
@@ -278,7 +279,7 @@ connection_cb(struct ev_loop *loop, struct ev_io *w, int revents) {
                               con->server.addr_len, loop);
             con->server.addr_once = NULL;
         } else {
-            buffer_send(output_buffer, w->fd, 0, loop);
+            bytes_transmitted = buffer_send(output_buffer, w->fd, 0, loop);
         }
 
         if (bytes_transmitted < 0 && 

--- a/src/connection.h
+++ b/src/connection.h
@@ -47,7 +47,7 @@ struct Connection {
 
     struct {
         struct sockaddr_storage addr, local_addr;
-        struct sockaddr_in * addr_once;
+        struct sockaddr *addr_once;
         socklen_t addr_len, local_addr_len;
         struct ev_io watcher;
         struct Buffer *buffer;

--- a/src/connection.h
+++ b/src/connection.h
@@ -46,6 +46,7 @@ struct Connection {
     } state;
 
     struct {
+	int fast_open;
         struct sockaddr_storage addr, local_addr;
         struct sockaddr *addr_once;
         socklen_t addr_len, local_addr_len;
@@ -58,7 +59,6 @@ struct Connection {
     size_t header_len;
     struct ResolvQuery *query_handle;
     ev_tstamp established_timestamp;
-    int fast_open;
     int use_proxy_header;
 
     TAILQ_ENTRY(Connection) entries;

--- a/src/connection.h
+++ b/src/connection.h
@@ -46,7 +46,6 @@ struct Connection {
     } state;
 
     struct {
-	int fast_open;
         struct sockaddr_storage addr, local_addr;
         struct sockaddr *addr_once;
         socklen_t addr_len, local_addr_len;

--- a/src/listener.h
+++ b/src/listener.h
@@ -39,7 +39,7 @@ struct Listener {
     const struct Protocol *protocol;
     char *table_name;
     struct Logger *access_log;
-    int log_bad_requests, reuseport, transparent_proxy, ipv6_v6only;
+    int log_bad_requests, fastopen, reuseport, transparent_proxy, ipv6_v6only;
     int fallback_use_proxy_header;
 
     /* Runtime fields */
@@ -58,6 +58,7 @@ int accept_listener_table_name(struct Listener *, const char *);
 int accept_listener_fallback_address(struct Listener *, const char *);
 int accept_listener_source_address(struct Listener *, const char *);
 int accept_listener_protocol(struct Listener *, const char *);
+int accept_listener_fastopen(struct Listener *, const char *);
 int accept_listener_reuseport(struct Listener *, const char *);
 int accept_listener_ipv6_v6only(struct Listener *, const char *);
 int accept_listener_bad_request_action(struct Listener *, const char *);

--- a/src/logger.c
+++ b/src/logger.c
@@ -401,24 +401,25 @@ obtain_file_sink(const char *filepath) {
             return sink;
     }
 
+    sink = malloc(sizeof(struct LogSink));
+    if (sink == NULL)
+        return NULL;
+
 
     FILE *fd = fopen(filepath, "a");
     if (fd == NULL) {
+        free(sink);
         err("Failed to open new log file: %s", filepath);
         return NULL;
     }
     setvbuf(fd, NULL, _IOLBF, 0);
 
+    sink->type = LOG_SINK_FILE;
+    sink->filepath = strdup(filepath);
+    sink->fd = fd;
+    sink->reference_count = 0;
 
-    sink = malloc(sizeof(struct LogSink));
-    if (sink != NULL) {
-        sink->type = LOG_SINK_FILE;
-        sink->filepath = strdup(filepath);
-        sink->fd = fd;
-        sink->reference_count = 0;
-
-        SLIST_INSERT_HEAD(&sinks, sink, entries);
-    }
+    SLIST_INSERT_HEAD(&sinks, sink, entries);
 
     return sink;
 }


### PR DESCRIPTION
@dlundquist Users can enable TCP Fast Open for both listening (server/frontend) and client (backend) sockets by adding one line to the `listen` section
```
listen * {
    # ...
    # frontend - fastopen server
    # backend - fastopen client
    # yes - fastopen client and server
    fastopen yes
    # ...
}
```