### PR TITLE
Inherit supplementary groups if no group has been specified

### DIFF
--- a/src/sniproxy.c
+++ b/src/sniproxy.c
@@ -233,11 +233,28 @@ drop_perms(const char *username, const char *groupname) {
         fatal("getgrnam(): group %s does not exist", groupname);
 
       gid = group->gr_gid;
-    }
 
-    /* drop any supplementary groups */
-    if (setgroups(1, &gid) < 0)
-        fatal("setgroups(): %s", strerror(errno));
+      /* drop any supplementary groups */
+      if (setgroups(1, &gid) < 0)
+          fatal("setgroups(): %s", strerror(errno));
+    } else {
+        /* if no group has been specified, load user's supplementary groups */
+        int ngroups = 0;
+        if (getgrouplist(user->pw_name, user->pw_gid, NULL, &ngroups) != -1)
+            fatal("getgrouplist(): %s", strerror(errno));
+
+        gid_t *groups = malloc(ngroups * sizeof(gid_t));
+        if (groups == NULL)
+            fatal("malloc(): %s", strerror(errno));
+
+        if (getgrouplist(user->pw_name, user->pw_gid, groups, &ngroups) < 0)
+            fatal("getgrouplist(): %s", strerror(errno));
+
+        if (setgroups(ngroups, groups) < 0)
+            fatal("setgroups(): %s", strerror(errno));
+
+        free(groups);
+    }
 
     /* set the main gid */
     if (setgid(gid) < 0)


### PR DESCRIPTION
This PR changes the behaviour of permission dropping, by inheriting user's supplementary group if no group has been explicitely specified in the configuration file.

The reason behind this PR is that I need to connect from sniproxy to a stunnel4 UNIX socket. Said sockets are created in Debian with permission 775 and user stunnel4, which means only users in the stunnel4 user and group can connect to said tunnels.

I thought about adding the sniproxy user to stunnel4 group so it could access the pipe, but it didn't work, and I spent quite some time figuring out why it was getting a connection refused even though the groups were properly set.

This PR thus allows using more than one group in the sniproxy user, which is more natural and behaves as in sudo or start-stop-daemon where the supplementary groups are also setup.