### PR TITLE
Fix Travis pipeline test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
   - gcc
 install:
   - sudo apt-get update
-  - DEBIAN_FRONTEND=noninteractive sudo apt-get install -y apache2-utils cdbs dh-autoreconf devscripts libev-dev libpcre3-dev libudns-dev lintian rpm valgrind
+  - DEBIAN_FRONTEND=noninteractive sudo apt-get install -y apache2-utils cdbs dh-autoreconf devscripts libev-dev libpcre3-dev libudns-dev lintian rpm valgrind fakeroot
   - mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
   - ./autogen.sh
 script:


### PR DESCRIPTION
There seems that at some point the Debian image Travis is using broke and now requires "fakeroot": https://travis-ci.org/dlundquist/sniproxy/jobs/602559628#L1423