### PR TITLE
Fix compilation issue with gcc >= 10

### DIFF
--- a/src/http.h
+++ b/src/http.h
@@ -29,6 +29,6 @@
 #include <stdio.h>
 #include "protocol.h"
 
-const struct Protocol *const http_protocol;
+extern const struct Protocol *const http_protocol;
 
 #endif

--- a/src/tls.h
+++ b/src/tls.h
@@ -28,6 +28,6 @@
 
 #include "protocol.h"
 
-const struct Protocol *const tls_protocol;
+extern const struct Protocol *const tls_protocol;
 
 #endif


### PR DESCRIPTION
Hi @dlundquist!

Thanks for your very useful project!

When compiling with gcc-10, we face the following error during compilation:

```
ld: listener.o:(.rodata+0x60): multiple definition of `http_protocol'; http.o:(.data.rel.ro.local+0x0): first defined here
ld: tls.o:(.data.rel.ro.local+0x0): multiple definition of `tls_protocol'; listener.o:(.rodata+0x68): first defined here
collect2: error: ld returned 1 exit status
```

This is due to the fact that, as of gcc 10, the code generator emits globals without explicit initializer from .bss to .data, [see here](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678). With older version, this can be achieve by adding the `-fno-common` option.

Please find attached a patch that prefix globals declarations with `extern` to avoid multiple definitions.

(For the record, this issue has been reported here: https://bugs.gentoo.org/707530)