### PR TITLE
Accept CRLF and LF in HTTP headers, fix buffer overflow error.

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -130,24 +130,27 @@ static size_t
 next_header(const char **data, size_t *len) {
     size_t header_len;
 
+    if (*len == 0)
+        return 0;
+
     /* perhaps we can optimize this to reuse the value of header_len, rather
      * than scanning twice.
      * Walk our data stream until the end of the header */
-    while (*len > 2 && (*data)[0] != '\r' && (*data)[1] != '\n') {
+    while (*len > 1 && (*data)[0] != '\n') {
         (*len)--;
         (*data)++;
     }
 
-    /* advanced past the <CR><LF> pair */
-    *data += 2;
-    *len -= 2;
+    /* advanced past the <LF> */
+    (*data)++;
+    (*len)--;
 
     /* Find the length of the next header */
     header_len = 0;
-    while (*len > header_len + 1
-            && (*data)[header_len] != '\r'
-            && (*data)[header_len + 1] != '\n')
+    while (*len > header_len && (*data)[header_len] != '\n')
         header_len++;
-
+    /* ignore preceding <CR> */
+    if (header_len > 0 && (*data)[header_len - 1] == '\r')
+        header_len--;
     return header_len;
 }

--- a/tests/http_test.c
+++ b/tests/http_test.c
@@ -20,6 +20,11 @@ static const char *good[] = {
         "HOST:\t     localhost:8080\r\n"
         "Accept: */*\r\n"
         "\r\n",
+    "GET / HTTP/1.1\n"
+        "User-Agent: curl/7.21.0 (x86_64-pc-linux-gnu) libcurl/7.21.0 OpenSSL/0.9.8o zlib/1.2.3.4 libidn/1.18\n"
+        "Host: localhost\n"
+        "Accept: */*\n"
+        "\n"
 };
 static const char *bad[] = {
     "GET / HTTP/1.0\r\n"


### PR DESCRIPTION
As per RFC 7230, section 3.5, the recipient MAY recognize a single LF as a line terminator and ignore any preceding CR for the start-line and header fields.

This feature is optional by HTTP specification, but it simplifies the scanning algorithm. Now we need to check for single character instead of two.

Also fix buffer overflow, which happens when data length is 0 (empty packet). This can be verified by simply putting assert(*len != 0) in next_header() function and by executing the tests `make check` afterwards.

Fixes: #366 