### PR TITLE
Fix IPv6 to IPv6 and IPv4 to IPv6 transparent proxying

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -643,23 +643,24 @@ initiate_server_connect(struct Connection *con, struct ev_loop *loop) {
          */
         struct in6_addr *saddr = &((struct sockaddr_in6 *)&con->client.addr)->sin6_addr;
         if (con->client.addr.ss_family == AF_INET6 &&
-                con->server.addr.ss_family == AF_INET6 &&
-                saddr->s6_addr[0] == 0 &&
-                saddr->s6_addr[1] == 0 &&
-                saddr->s6_addr[2] == 0 &&
-                saddr->s6_addr[3] == 0 &&
-                saddr->s6_addr[4] == 0 &&
-                saddr->s6_addr[5] == 0 &&
-                saddr->s6_addr[6] == 0 &&
-                saddr->s6_addr[7] == 0 &&
-                saddr->s6_addr[8] == 0 &&
-                saddr->s6_addr[9] == 0 &&
-                saddr->s6_addr[10] == 0xff &&
-                saddr->s6_addr[11] == 0xff) {
+                con->server.addr.ss_family == AF_INET6)
+            if (saddr->s6_addr[0] == 0 &&
+                    saddr->s6_addr[1] == 0 &&
+                    saddr->s6_addr[2] == 0 &&
+                    saddr->s6_addr[3] == 0 &&
+                    saddr->s6_addr[4] == 0 &&
+                    saddr->s6_addr[5] == 0 &&
+                    saddr->s6_addr[6] == 0 &&
+                    saddr->s6_addr[7] == 0 &&
+                    saddr->s6_addr[8] == 0 &&
+                    saddr->s6_addr[9] == 0 &&
+                    saddr->s6_addr[10] == 0xff &&
+                    saddr->s6_addr[11] == 0xff) {
 
-            /* Turn (e.g.) IPv4 ::ffff:192.0.2.1 into IPv6 ::192.0.2.1 */
-            saddr->s6_addr[10] = 0;
-            saddr->s6_addr[11] = 0;
+                /* Turn (e.g.) IPv4 ::ffff:192.0.2.1 into IPv6 ::192.0.2.1 */
+                saddr->s6_addr[10] = 0;
+                saddr->s6_addr[11] = 0;
+            }
 
             /* We want an IPv6 transparent socket */
             int on = 1;

--- a/src/connection.c
+++ b/src/connection.c
@@ -631,8 +631,44 @@ initiate_server_connect(struct Connection *con, struct ev_loop *loop) {
     if (con->listener->transparent_proxy &&
             con->client.addr.ss_family == con->server.addr.ss_family) {
 #ifdef IP_TRANSPARENT
-        int on = 1;
-        int result = setsockopt(sockfd, SOL_IP, IP_TRANSPARENT, &on, sizeof(on));
+        int result;
+        /* Make an IPv6 socket if necessary and purge ::ffff: from the v6-mapped address
+         * We need to take out the ffff because otherwise it'll be IPv4 on the wire.
+         * The result is a connection from IPv6 address ::<ipv4>,
+         * The return traffic can be marked with nftables in ip6 mangle PREROUTING:
+         * socket transparent 1 mark set 0x1
+         * and then routed to sniproxy using a separate routing table (e.g table 100):
+         * ip -6 rule add fwmark 0x1 lookup 100
+         * ip -6 route add local ::/96 dev lo table 100
+         */
+        struct in6_addr *saddr = &((struct sockaddr_in6 *)&con->client.addr)->sin6_addr;
+        if (con->client.addr.ss_family == AF_INET6 &&
+                con->server.addr.ss_family == AF_INET6 &&
+                saddr->s6_addr[0] == 0 &&
+                saddr->s6_addr[1] == 0 &&
+                saddr->s6_addr[2] == 0 &&
+                saddr->s6_addr[3] == 0 &&
+                saddr->s6_addr[4] == 0 &&
+                saddr->s6_addr[5] == 0 &&
+                saddr->s6_addr[6] == 0 &&
+                saddr->s6_addr[7] == 0 &&
+                saddr->s6_addr[8] == 0 &&
+                saddr->s6_addr[9] == 0 &&
+                saddr->s6_addr[10] == 0xff &&
+                saddr->s6_addr[11] == 0xff) {
+
+            /* Turn (e.g.) IPv4 ::ffff:192.0.2.1 into IPv6 ::192.0.2.1 */
+            saddr->s6_addr[10] = 0;
+            saddr->s6_addr[11] = 0;
+
+            /* We want an IPv6 transparent socket */
+            int on = 1;
+            result = setsockopt(sockfd, SOL_IPV6, IPV6_TRANSPARENT, &on, sizeof(on));
+        } else {
+            /* We want an IPv4 transparent socket */
+            int on = 1;
+            result = setsockopt(sockfd, SOL_IP, IP_TRANSPARENT, &on, sizeof(on));
+        }
 #else
         int result = -EPERM;
         /* XXX error: not implemented would be better, but this shouldn't be


### PR DESCRIPTION
Hi,

Currently, when the client is IPv4 and the destination is IPv4, transparent proxying works.
When the client is IPv6 and the destination is IPv6, it does not, because the wrong type of socket is created.
When the client is IPv4 and the destination is IPv6, no mapping is done and an address family error is thrown.

The address family error is thrown because when using ::ffff:192.0.2.1 as source address, the socket will create an IPv4 packet, not an IPv6 packet.

This patch fixes the socket type for IPv6 to IPv6, and also changes the source address from ::ffff:192.0.2.1 to ::192.0.2.1 for IPv4 to IPv6.

In the server logs on the destinations the IPv4-address is as human readable as possible, and replies go to ::0.0.0.0/96.

These replies can be captured using:
ip6tables -t mangle -A PREROUTING -m socket --transparent -j MARK --set-mark 1
ip -6 rule add fwmark 0x1 lookup 100
ip -6 route add local ::/96 dev lo table 100

With nftables in the table ip6 mangle chain PREROUTING: socket transparent 1 mark set 0x1 accept

