### PR TITLE
Don't define http_protocol and tls_protocol variables multiple times.…

### DIFF
--- a/src/http.h
+++ b/src/http.h
@@ -29,6 +29,6 @@
 #include <stdio.h>
 #include "protocol.h"
 
-const struct Protocol *const http_protocol;
+extern const struct Protocol *const http_protocol;
 
 #endif

--- a/src/tls.h
+++ b/src/tls.h
@@ -28,6 +28,6 @@
 
 #include "protocol.h"
 
-const struct Protocol *const tls_protocol;
+extern const struct Protocol *const tls_protocol;
 
 #endif


### PR DESCRIPTION
… (#1)

As of gcc 10, the code generator emits globals without explicit initializer
from .bss to .data, leading to:

ld: listener.o:(.rodata+0x60): multiple definition of `http_protocol'; http.o:(.data.rel.ro.local+0x0): first defined here
ld: tls.o:(.data.rel.ro.local+0x0): multiple definition of `tls_protocol'; listener.o:(.rodata+0x68): first defined here
collect2: error: ld returned 1 exit status

Co-authored-by: Pierre-Olivier Mercier <nemunaire@nemunai.re>
Co-authored-by: Dustin Lundquist <dustin@null-ptr.net>