### PR TITLE
Don't use transparent proxying for clients on the listener itself

### DIFF
--- a/src/address.c
+++ b/src/address.c
@@ -34,6 +34,7 @@
 #include <arpa/inet.h> /* inet_pton */
 #include <sys/un.h>
 #include <assert.h>
+#include <string.h>
 #include "address.h"
 
 
@@ -257,6 +258,30 @@ address_compare(const struct Address *addr_1, const struct Address *addr_2) {
     }
 
     return result;
+}
+
+int
+address_addr_eq(const struct Address *addr, const struct sockaddr *sa) {
+    if (addr->type != SOCKADDR)
+        return 0;
+
+    if (address_sa(addr)->sa_family != sa->sa_family)
+        return 0;
+
+    switch (address_sa(addr)->sa_family) {
+        case AF_INET:
+            return !memcmp(&((struct sockaddr_in *)addr->data)->sin_addr,
+                    &((struct sockaddr_in *)sa)->sin_addr,
+                    sizeof(((struct sockaddr_in *)sa)->sin_addr));
+
+        case AF_INET6:
+            return !memcmp(&((struct sockaddr_in6 *)addr->data)->sin6_addr,
+                    &((struct sockaddr_in6 *)sa)->sin6_addr,
+                    sizeof(((struct sockaddr_in6 *)sa)->sin6_addr));
+
+        default:
+            return 0;
+    }
 }
 
 int

--- a/src/address.h
+++ b/src/address.h
@@ -44,6 +44,7 @@ struct Address *new_address_sa(const struct sockaddr *, socklen_t);
 struct Address *copy_address(const struct Address *);
 size_t address_len(const struct Address *);
 int address_compare(const struct Address *, const struct Address *);
+int address_addr_eq(const struct Address *, const struct sockaddr *);
 int address_is_hostname(const struct Address *);
 int address_is_sockaddr(const struct Address *);
 int address_is_wildcard(const struct Address *);


### PR DESCRIPTION
It's not possible to bind to the same address and port when the client is the same as the listener because it will already be in use by the incoming connection. Detect this and use a new port on the same address instead.